### PR TITLE
Add the deployment step to notify the RCR-UI that a refresh is needed

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -20,6 +20,7 @@ on:
   push:
     branches:
       - main
+      - asymingt/trigger-the-rcr-ui-automatically # TODO remove before merge
 
 permissions:
   contents: write
@@ -54,3 +55,11 @@ jobs:
       uses: JamesIves/github-pages-deploy-action@v4
       with:
         folder: docs
+
+    # Notify the RCR-UI that it needs to regenerate its pages.
+    - name: Notify the RCR-UI that an update is needed
+      uses: peter-evans/repository-dispatch@v4
+      with:
+        token: ${{ secrets.RCR_UI_PAT_TOKEN }}
+        repository: intrinsic-opensource/rcr-ui
+        event-type: on-rcr-trigger


### PR DESCRIPTION
This is the last step in automating the deployment of an updated `rcr-ui` web page. It uses a repo secret to trigger the rcr-ui action into regenerating pages whenever a merge is made to `main`.