### PR TITLE
feat: Switch to hermetic-llvm toolchain

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -38,7 +38,7 @@ test --sandbox_default_allow_network=true
 # Use C++17 standard by default across the whole repo.
 build --cxxopt="-std=c++17"
 
-# Ensure that we use toolchains_llvm instead of the host toolchain.
+# Ensure that we use the hermetic LLVM C++ toolchain instead of the host toolchain.
 build --action_env="BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1"
 
 # Tell Bazel to use the pre-compiled binary instead of building from source

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -25,6 +25,7 @@ bazel_dep(name = "bazel_skylib", version = "1.9.0")
 bazel_dep(name = "cmake_configure_file", version = "0.1.6")
 bazel_dep(name = "google_benchmark", version = "1.9.4")
 bazel_dep(name = "googletest", version = "1.17.0.bcr.2")
+bazel_dep(name = "llvm", version = "0.8.11")
 bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "protobuf", version = "33.4")
 bazel_dep(name = "rules_cc", version = "0.2.17")
@@ -32,7 +33,6 @@ bazel_dep(name = "rules_python", version = "1.8.3")
 bazel_dep(name = "aspect_rules_py", version = "1.8.6")
 bazel_dep(name = "rules_rust", version = "0.68.1")
 bazel_dep(name = "rules_shell", version = "0.6.1")
-bazel_dep(name = "toolchains_llvm", version = "1.6.0")
 bazel_dep(name = "userspace_rcu", version = "0.15.4")
 
 # Third party (things we intend to add to the BCR)
@@ -1405,11 +1405,7 @@ local_path_override(
 
 # C++ toolchain (offers amd64 and arm64 for linux, windows and darwin)
 
-llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm")
-llvm.toolchain(llvm_version = "20.1.7")
-use_repo(llvm, "llvm_toolchain")
-
-register_toolchains("@llvm_toolchain//:all")
+register_toolchains("@llvm//toolchain:all")
 
 # Python configuration
 


### PR DESCRIPTION
Closes https://github.com/intrinsic-opensource/ros-central-registry/pull/103

Switches C++ toolchain to https://github.com/hermeticbuild/hermetic-llvm

With the following changes to submodules:
- https://github.com/asymingt/rosidl/pull/1
- https://github.com/asymingt/rcutils/pull/1