### PR TITLE
chore: make examples build much faster

### DIFF
--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -33,7 +33,7 @@ bazel_dep(name = "rules_shell", version = "0.8.0")
 ## RCR deps
 
 # Load the 'perception' variant for lyrical/2026-06-08.
-bazel_dep(name = "ros", version = "lyrical.2026-06-08.rcr.1")
+bazel_dep(name = "perception", version = "lyrical.2026-06-08.rcr.1")
 
 # Make the following packages visible to this project. We use the dummy package
 # version "0.0.0" to satisfy Bazel's need for a version, but be guaranteed that

--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -61,7 +61,6 @@ bazel_dep(name = "examples_rclpy_minimal_service", version = "0.0.0")
 bazel_dep(name = "examples_rclpy_minimal_subscriber", version = "0.0.0")
 bazel_dep(name = "examples_rclpy_pointcloud_publisher", version = "0.0.0")
 bazel_dep(name = "examples_tf2_py", version = "0.0.0")
-bazel_dep(name = "rclc", version = "0.0.0")
 bazel_dep(name = "rclcpp", version = "0.0.0")
 bazel_dep(name = "rclpy", version = "0.0.0")
 bazel_dep(name = "rosdistro", version = "0.0.0")
@@ -69,6 +68,10 @@ bazel_dep(name = "rosidl_core_generators", version = "0.0.0")
 bazel_dep(name = "rmw_implementation", version = "0.0.0")
 bazel_dep(name = "sensor_msgs", version = "0.0.0")
 bazel_dep(name = "std_msgs", version = "0.0.0")
+
+# The C examples require rclc, which is not part of the "perception" variant.
+# Nevertheless, we can bring the package in if we know its version.
+bazel_dep(name = "rclc", version = "6.3.0-3.rcr.1")
 
 ## BOOTSTRAP
 


### PR DESCRIPTION
Adding `bazel_dep` on `perception` is far more efficient in terms of how many registries are pulled.