### PR TITLE
Update tooling after dogfooding it to myself.

### DIFF
--- a/.agent/skills/create-patch/SKILL.md
+++ b/.agent/skills/create-patch/SKILL.md
@@ -60,9 +60,11 @@ Useful flags in this mode:
 Exactly the new version directory/directories under `modules/<package>/`,
 plus the corresponding `metadata.json` updates (a new entry appended to
 `versions`) — nothing else. **Never** touch an existing version directory or
-any other package's files: `tools/ci/check_pr_modules.py` enforces this in
-CI and will fail the PR otherwise (see the immutability rule in
-`AGENTS.md`).
+any other package's files, with two exceptions: (1) `metadata.json` files can
+be modified to add versions or yanked versions, and (2) `MODULE.bazel` files
+can have their version argument bumped by exactly one patch suffix (any other edits
+are forbidden). Edits to `rosdistro`'s `MODULE.bazel` are exempt from the version-bump-only rule.
+`tools/ci/check_pr_modules.py` enforces this in CI and will fail the PR otherwise (see the immutability rule in `AGENTS.md`).
 
 When you open the PR, fill out every section of
 `.github/PULL_REQUEST_TEMPLATE.md` (GitHub applies it to the description

--- a/.agent/skills/edit-module/SKILL.md
+++ b/.agent/skills/edit-module/SKILL.md
@@ -1,0 +1,252 @@
+---
+name: edit-module
+description: Add, fix, or patch Bazel modules in the ROS Central Registry. Describes the end-to-end setup-vendor-edit-patch workflow, overlay rules (including ros_interface files), licensing rules, dependency constraints, and MODULE.bazel validation rules.
+---
+
+Editing, fixing, or patching Bazel modules in the ROS Central Registry (RCR) follows a structured setup, vendor, edit, and patch pipeline. You must always use the automated tools (`setup_workspace`, `vendor_modules`, and `create_patch`) rather than manually creating or editing files under `modules/` directly.
+
+## The Workflow
+
+### 1. Set Up a Throwaway Workspace
+Generate a local, gitignored Bazel workspace for the targeted release (e.g. `lyrical.2026-06-08.rcr.1`).
+```shell
+bazel run //tools/ci:setup_workspace -- --release=<release-name>
+```
+For more details, see the `setup-workspace` skill.
+
+### 2. Vendor the Module
+Check out the package's real upstream source with all existing patches/overlays already applied into `workspace/vendor/<module-name>+/`.
+```shell
+cd workspace
+bazel run //tools/ci:vendor_modules -- <module-name>
+```
+> [!NOTE]
+> You might need to vendor additional dependencies (other ROS packages) required by your target module if they aren't fully implemented or are only partially implemented yet. You can vendor multiple packages at the same time:
+> ```shell
+> bazel run //tools/ci:vendor_modules -- package_a package_b
+> ```
+For more details, see the `vendor-module` skill.
+
+### 3. Make Edits and Test
+Modify files, write new files, or configure build files inside `workspace/vendor/<module-name>+/`. Test your changes directly using Bazel:
+```shell
+bazel build @<module-name>//...
+bazel test @<module-name>//...
+```
+
+### 4. Create the Patch
+Roll up all your edits relative to raw upstream into a new module version directory under `modules/<package>/<new-version>/`:
+```shell
+cd ..
+bazel run //tools/ci:create_patch -- <module-name>
+```
+This increments the `.rcr.N` patch version (e.g. `1.0.0-1.rcr.1` -> `1.0.0-1.rcr.2`), updates `metadata.json` to include the new version, and auto-generates:
+- `source.json` (with updated patch/overlay integrity hashes)
+- `overlay/` (for brand-new files like `BUILD.bazel`)
+- `patches/` (diffs of files modified in place)
+
+If you touched multiple packages, running `bazel run //tools/ci:create_patch` with no arguments will roll up all changed modules at once.
+
+> [!NOTE]
+> While a PR can contain changes/additions for more than one module, large PRs affecting multiple unrelated modules are discouraged. Prefer submitting smaller, focused PRs per module (or per closely-related set of modules) to make reviews and CI runs more manageable.
+
+---
+
+## Writing `BUILD.bazel` Overlays
+
+When creating or modifying a package's `BUILD.bazel` file, keep the following guidelines in mind:
+
+### 1. Declaring Licensing
+Every newly authored or hand-edited `BUILD.bazel` file should declare the package's license using `rules_license`. Ensure the license matches the package's actual upstream license (defined in its `package.xml` `<license>` tag or LICENSE file).
+```python
+load("@rules_license//rules:license.bzl", "license")
+
+package(
+    default_applicable_licenses = [":license"],
+    default_visibility = ["//visibility:public"],
+)
+
+license(
+    name = "license",
+    license_kinds = [
+        "@rules_license//licenses/spdx:BSD-3-Clause", # Match package.xml
+    ],
+)
+```
+
+### 2. ROS Interface Files (`.msg`, `.srv`, `.action`)
+ROS interface files must be declared using the `ros_interface` Bazel rule.
+> [!IMPORTANT]
+> The `BUILD.bazel` declaring `ros_interface` must live in the **same directory** as the interface files (e.g. inside the package's `msg/`, `srv/`, or `action/` directory, rather than the root directory). The codegen tooling reconstructs paths relative to the build file's folder, so placing the `BUILD.bazel` file higher up will break the build.
+
+To generate the code bindings and ament_index for these interfaces, check the package dependencies (usually in `package.xml` or `MODULE.bazel`):
+- If the package depends on `rosidl_core_generators`, load and call `core_generators`.
+- If the package depends on `rosidl_default_generators`, load and call `default_generators`.
+
+These macros are declared in the package's root `BUILD.bazel` file, referencing the complete list of interfaces:
+```python
+load("@rosidl_default_generators//:defs.bzl", "default_generators")
+
+default_generators(
+    package_xml = "package.xml",
+    deps = [
+        "//msg:GoalInfo",
+        "//msg:GoalStatus",
+        "//srv:CancelGoal",
+    ],
+)
+```
+This automatically sets up all language targets (C++, Python, etc.) and an `ament_index` for the package.
+
+Finally, declare an `ament_package` target bundling this package by listing upstream `ament_package` targets of all dependencies:
+```python
+load("@rosdistro//ament:defs.bzl", "ament_package")
+
+ament_package(
+    name = "ament_package",
+    package_xml = "package.xml",
+    deps = [
+        ":ament_index",
+        # List other package dependencies' ament_package targets here...
+    ],
+)
+```
+
+For reference implementations, inspect the `action_msgs` or `actuator_msgs` modules.
+
+### 3. C/C++ Libraries and Shared Libraries
+For package stability, mock testing, and minimizing the runfile footprint, RCR requires C or C++ libraries to expose both:
+- A static target: `cc_library` named `:<name>_library` (containing sources/headers/defines).
+- A dynamic shared library target: `cc_shared_library` named `:<name>` (exporting/wrapping the static target).
+
+```python
+cc_library(
+    name = "my_lib_library",
+    srcs = glob(["src/**/*.cpp"]),
+    hdrs = glob(["include/**/*.hpp"]),
+    includes = ["include"],
+    deps = [
+        "@rclcpp//:rclcpp_library",
+    ],
+)
+
+cc_shared_library(
+    name = "my_lib",
+    dynamic_deps = [
+        "@rclcpp//:rclcpp",
+    ],
+    exports_filter = [":my_lib_library"],
+    deps = [":my_lib_library"],
+)
+```
+
+#### Transitive Dynamic Dependency Collection
+To ensure binaries (e.g. `cc_binary`) and tests (e.g. `cc_test`) are linked correctly, you must call `collect_transitive_dynamic_deps` right before defining the binary/test targets.
+- Load the helper macro:
+  ```python
+  load("@rosdistro//cc:defs.bzl", "collect_transitive_dynamic_deps")
+  ```
+- Declare the dependency map and call `collect_transitive_dynamic_deps`:
+  ```python
+  # Map dynamic targets (keys) to their static library targets (values)
+  TEST_DEPENDENCIES = {
+      ":my_lib": ":my_lib_library",
+      "@rclcpp//:rclcpp": "@rclcpp//:rclcpp_library",
+  }
+
+  collect_transitive_dynamic_deps(
+      name = "transitive_dynamic_deps",
+      dynamic_deps = TEST_DEPENDENCIES.keys(),
+      visibility = ["//visibility:private"],
+  )
+  ```
+- Pass `transitive_dynamic_deps` as `dynamic_deps` and use the static libraries under `deps`:
+  ```python
+  cc_test(
+      name = "my_test",
+      srcs = ["test/my_test.cpp"],
+      dynamic_deps = [":transitive_dynamic_deps"],
+      deps = TEST_DEPENDENCIES.values() + [
+          "@rosdistro//cc:googletest",
+      ],
+  )
+  ```
+
+For reference implementations, inspect the `rosbag2_cpp` or `filters` modules.
+
+---
+
+## ROS Package Packaging with Ament (Ament Index & Ament Package)
+
+Many ROS packages rely on the `ament_index` to locate plugins, resources, or configurations at runtime. In Bazel, we simulate the `AMENT_PREFIX_PATH` structure in the Bazel runfiles directory.
+
+To support this, we follow a specific layout in `BUILD.bazel` using rules loaded from `@rosdistro//ament:defs.bzl`:
+```python
+load("@rosdistro//ament:defs.bzl", "ament_index", "ament_package")
+```
+
+### 1. The `ament_index` Rule
+The `ament_index` target aggregates the package XML, libraries, plugins, and transitively links the `ament_index` of all dependencies:
+```python
+ament_index(
+    name = "ament_index",
+    export_name = "package_name",
+    libraries = [":package_name"], # libraries/plugins exported by this package
+    package_xml = "package.xml",
+    # Optional list of plugin XML configurations:
+    plugins = ["plugin.xml"],
+    deps = [
+        # List the :ament_index target of every bazel_dep dependency
+        "@dependency_a//:ament_index",
+        "@dependency_b//:ament_index",
+    ],
+)
+```
+
+### 2. Passing to Targets (Data Dependency)
+Feed `:ament_index` into the `data` attribute of any executables or test targets in the current package. This ensures the libraries, executables, and registered files appear correctly in the runfiles directory at runtime (which serves as the local `AMENT_PREFIX_PATH`):
+```python
+cc_test(
+    name = "my_test",
+    srcs = ["test.cpp"],
+    data = [":ament_index"],
+    deps = [...],
+)
+```
+
+### 3. The `ament_package` Rule
+At the end of the `BUILD.bazel` file, declare the `ament_package` rule. It acts as the final bundling rule for downstream consumers, depending on `:ament_index` and the `:ament_package` target of all dependencies:
+```python
+ament_package(
+    name = "ament_package",
+    headers = HEADERS,
+    libraries = [":package_name"],
+    package_xml = "package.xml",
+    deps = [
+        ":ament_index", # transitely pulls in all upstream dependencies' ament_package targets
+    ],
+)
+```
+
+---
+
+## Managing Dependencies
+
+### 1. Non-ROS / Third-Party (BCR) Dependencies
+Never declare new `bazel_dep` entries in a package's own `MODULE.bazel`. Instead:
+1. Add the `bazel_dep` (and any module extensions/repository rules) to the `rosdistro` module's `MODULE.bazel`.
+2. Wrap and expose the dependency in `modules/rosdistro/<version>/overlay/cc/BUILD.bazel` (e.g. wrapping it as a target like `@rosdistro//cc:<target>`).
+3. Make the package depend on `@rosdistro//cc:<target>`.
+
+This ensures all packages in a given distro release resolve to the exact same version of third-party dependencies.
+
+### 2. Python Dependencies
+Add Python packages to `rosdistro`'s `requirements.in`, then run `bazel run //:requirements.update` to update the locks. Do not edit `requirements.txt` or `requirements_windows.txt` by hand.
+
+---
+
+## MODULE.bazel Validation Rules
+
+CI enforces that existing version directories are immutable once merged to `main`.
+- **Allowed MODULE.bazel Edits**: The only acceptable modification to an existing `MODULE.bazel` file is the `version` argument being incremented by exactly one patch suffix (e.g., `1.0.0-1.rcr.1` to `1.0.0-1.rcr.2`). Any other change will fail validation.
+- **`rosdistro` Exception**: The `rosdistro` module is exempt from this version-bump-only rule and allows general modifications to its `MODULE.bazel` (e.g., adding BCR dependencies).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,25 +9,11 @@ this repo expects PRs to follow.
 
 <!-- What does this PR do, and why? -->
 
-## Packages affected
-
-<!--
-List every RCR package (module) this PR touches, e.g. the modules/<name>/
-directories with a new version. Per CONTRIBUTING.md, a single patch PR should
-normally touch exactly one package's new version directory plus its
-metadata.json.
--->
-
--
-
 ## Acknowledgements
 
 - [ ] I have read the [Contributing Guidelines](../CONTRIBUTING.md).
-- [ ] I have read the [Code of Conduct](../CODE_OF_CONDUCT.md) and agree to
-      abide by it.
-- [ ] I have read and complied with the [OSRF Policy on the Use of
-      Generative AI Tools ("Generative AI") in
-      Contributions](https://github.com/openrobotics/osra-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md).
+- [ ] I have read the [Code of Conduct](../CODE_OF_CONDUCT.md) and agree to abide by it.
+- [ ] I have read and complied with the [OSRF Policy on the Use of Generative AI Tools ("Generative AI") in Contributions](https://github.com/openrobotics/osra-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md).
 
 ## Generative AI disclosure
 

--- a/.github/workflows/_check_bazel_modules.yml
+++ b/.github/workflows/_check_bazel_modules.yml
@@ -68,9 +68,9 @@ jobs:
         # Generate the diff name-status file
         git diff --name-status "origin/$BASE_REF...HEAD" > /tmp/diff_status.txt
 
-        # Extract the old versions of any modified metadata.json files under the matrix directory
+        # Extract the old versions of any modified metadata.json or MODULE.bazel files under the matrix directory
         mkdir -p /tmp/old_metadata
-        git diff --name-only "origin/$BASE_REF...HEAD" | grep "^${{ matrix.directory }}/[^/]*/metadata.json$" | while read -r file; do
+        git diff --name-only "origin/$BASE_REF...HEAD" | grep -E "^${{ matrix.directory }}/[^/]*/metadata.json$|^${{ matrix.directory }}/[^/]*/[^/]*/MODULE.bazel$" | while read -r file; do
             mkdir -p "/tmp/old_metadata/$(dirname "$file")"
             git show "origin/$BASE_REF:$file" > "/tmp/old_metadata/$file" || true
         done

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,8 +40,10 @@ and packages what already exists upstream in
 4. **Bazel modules are immutable once merged to `main`.** A version directory
    under `modules/<package>/<version>/` is never edited, renamed, or deleted
    after merge — CI enforces this (`tools/ci/check_pr_modules.py`: any diff
-   under `modules/` that isn't a brand-new version directory, or an append-only
-   edit to `metadata.json`, fails). Fixing a bug in a package means creating a
+   under `modules/` that isn't a brand-new version directory, an append-only
+   edit to `metadata.json`, or a version-bump-only modification to `MODULE.bazel`,
+   fails). The only exception is the `rosdistro` module, which permits any edits
+   to its `MODULE.bazel` files. Fixing a bug in a package means creating a
    **new** version directory (e.g. `rclcpp@32.0.0-1.rcr.1` ->
    `rclcpp@32.0.0-1.rcr.2`), never editing the old one in place.
 
@@ -60,6 +62,29 @@ patch pipeline — see the skills in `.agent/skills/`:
   everything you touched.
 - `.agent/skills/release-automation/` — what's automated (bootstrap, rollup)
   and what you should never try to do by hand.
+
+## Adding a new third-party (BCR) dependency
+
+Never add a new `bazel_dep` to a package's own `MODULE.bazel` (e.g. because
+its `CMakeLists.txt` needs something not already declared there, such as a
+prebuilt SDK upstream fetches via CMake `FetchContent`). Only `rosdistro`'s
+`MODULE.bazel` gains new BCR deps. Add the `bazel_dep` (and any module
+extension/repository rule needed to fetch it, e.g. a platform-specific
+prebuilt release archive) there instead, then expose it as a
+`cc_library`/`cc_shared_library` target in `rosdistro`'s `overlay/cc/BUILD.bazel`
+(see the `mcap`/`zstd`/`fastdds` targets there for the pattern of wrapping an
+upstream BCR target, and `bazel_test_helper`/`googletest` for small
+from-source helper libraries). Packages that need the dependency then depend
+on `@rosdistro//cc:<target>` rather than declaring the BCR dep themselves.
+
+This forces every package in a given distro release to pin to the exact same
+version of any transitive (non-ROS) dependency, instead of letting individual
+packages drift to their own versions.
+
+The same centralization applies to Python dependencies: add the package to
+`rosdistro`'s `requirements.in`, then regenerate both locks rather
+than hand-editing them — `bazel run //:requirements.update` for
+`requirements.txt` (see its own header comment).
 
 ## Repository layout
 

--- a/tools/ci/check_pr_modules.py
+++ b/tools/ci/check_pr_modules.py
@@ -16,10 +16,11 @@
 import argparse
 import json
 import os
+import re
 import sys
 from pathlib import Path
 
-from tools.ci.bzlmod_lib import parse_diff_status_file
+from tools.ci.bzlmod_lib import increment_version, parse_diff_status_file
 
 def check_metadata_json(file_path: str, old_metadata_dir: Path, working_dir: Path) -> list[str]:
     violations = []
@@ -73,6 +74,85 @@ def check_metadata_json(file_path: str, old_metadata_dir: Path, working_dir: Pat
 
     return violations
 
+def check_module_bazel(file_path: str, old_metadata_dir: Path, working_dir: Path, package_name: str) -> list[str]:
+    violations = []
+
+    # If it is the rosdistro module, we allow any edits.
+    if package_name == "rosdistro":
+        return violations
+
+    # Otherwise, check the only change is the version argument bumping the patch suffix by one.
+    old_module_path = old_metadata_dir / file_path
+    if not old_module_path.exists():
+        violations.append(f"Old MODULE.bazel file {file_path} not found in {old_metadata_dir}.")
+        return violations
+
+    new_module_path = working_dir / file_path
+    if not new_module_path.exists():
+        violations.append(f"Modified file {file_path} does not exist in the working directory.")
+        return violations
+
+    try:
+        with open(old_module_path, "r") as f:
+            old_content = f.read()
+    except Exception as e:
+        violations.append(f"Failed to read old MODULE.bazel in {file_path}: {e}")
+        return violations
+
+    try:
+        with open(new_module_path, "r") as f:
+            new_content = f.read()
+    except Exception as e:
+        violations.append(f"Failed to read new MODULE.bazel in {file_path}: {e}")
+        return violations
+
+    pattern = re.compile(
+        r'module\(\s*name\s*=\s*["\']([^"\']+)["\']\s*,\s*version\s*=\s*["\']([^"\']+)["\']'
+    )
+
+    old_match = pattern.search(old_content)
+    if not old_match:
+        violations.append(f"Could not find module declaration for '{package_name}' in old MODULE.bazel {file_path}")
+        return violations
+
+    old_name, old_version = old_match.groups()
+    if old_name != package_name:
+        violations.append(f"Module name mismatch in old MODULE.bazel: expected '{package_name}', found '{old_name}'")
+        return violations
+
+    new_match = pattern.search(new_content)
+    if not new_match:
+        violations.append(f"Could not find module declaration for '{package_name}' in new MODULE.bazel {file_path}")
+        return violations
+
+    new_name, new_version = new_match.groups()
+    if new_name != package_name:
+        violations.append(f"Module name mismatch in new MODULE.bazel: expected '{package_name}', found '{new_name}'")
+        return violations
+
+    try:
+        expected_version = increment_version(old_version)
+    except ValueError as e:
+        violations.append(f"Failed to increment version '{old_version}': {e}")
+        return violations
+
+    if new_version != expected_version:
+        violations.append(
+            f"MODULE.bazel version was changed from '{old_version}' to '{new_version}', "
+            f"but it should have been incremented to '{expected_version}'."
+        )
+        return violations
+
+    # Replace the new version string back to the old version string in new_content
+    normalized_new_content = (
+        new_content[:new_match.start(2)] + old_version + new_content[new_match.end(2):]
+    )
+
+    if normalized_new_content != old_content:
+        violations.append(f"MODULE.bazel has modifications other than the version bump: {file_path}")
+
+    return violations
+
 def check_violations(diffs: list[tuple[str, str]], old_metadata_dir: Path, working_dir: Path, target_dir: str) -> list[str]:
     violations = []
     
@@ -95,7 +175,7 @@ def check_violations(diffs: list[tuple[str, str]], old_metadata_dir: Path, worki
             violations.append(f"Renamed file in {prefix}: {file_path}")
             continue
 
-        # Rule 3: Only metadata.json files can be modified under target_dir
+        # Rule 3: Only metadata.json and MODULE.bazel files can be modified under target_dir
         if status.startswith("M"):
             path_parts = Path(file_path).parts
             is_metadata = (
@@ -104,14 +184,23 @@ def check_violations(diffs: list[tuple[str, str]], old_metadata_dir: Path, worki
                 path_parts[-1] == "metadata.json"
             )
             
-            if not is_metadata:
-                violations.append(f"Modified existing file (only metadata.json files can be modified): {file_path}")
+            is_module_bazel = (
+                len(path_parts) == len(target_parts) + 3 and
+                path_parts[:len(target_parts)] == target_parts and
+                path_parts[-1] == "MODULE.bazel"
+            )
+
+            if is_metadata:
+                meta_violations = check_metadata_json(file_path, old_metadata_dir, working_dir)
+                violations.extend(meta_violations)
+            elif is_module_bazel:
+                package_name = path_parts[len(target_parts)]
+                module_violations = check_module_bazel(file_path, old_metadata_dir, working_dir, package_name)
+                violations.extend(module_violations)
+            else:
+                violations.append(f"Modified existing file (only metadata.json and MODULE.bazel files can be modified): {file_path}")
                 continue
 
-            # For modified metadata.json, check version rules
-            meta_violations = check_metadata_json(file_path, old_metadata_dir, working_dir)
-            violations.extend(meta_violations)
-            
     return violations
 
 def main():

--- a/tools/ci/check_pr_modules_test.py
+++ b/tools/ci/check_pr_modules_test.py
@@ -78,12 +78,12 @@ class TestCheckPrModules(unittest.TestCase):
         self.assertIn("Renamed file in modules/: modules/existing_module/1.0.0/MODULE.bazel", violations)
 
     def test_modified_non_metadata_forbidden(self):
-        # Modifying non-metadata.json files is forbidden
+        # Modifying non-metadata.json/MODULE.bazel files is forbidden
         diffs = [
-            ("M", "modules/existing_module/1.0.0/MODULE.bazel")
+            ("M", "modules/existing_module/1.0.0/source.json")
         ]
         violations = check_violations(diffs, self.old_dir, self.work_dir, "modules")
-        self.assertIn("Modified existing file (only metadata.json files can be modified): modules/existing_module/1.0.0/MODULE.bazel", violations)
+        self.assertIn("Modified existing file (only metadata.json and MODULE.bazel files can be modified): modules/existing_module/1.0.0/source.json", violations)
 
     def test_modified_metadata_allowed_add_version(self):
         # Modifying metadata.json to add a new version is allowed
@@ -134,6 +134,97 @@ class TestCheckPrModules(unittest.TestCase):
         diffs = [("M", rel_path)]
         violations = check_violations(diffs, self.old_dir, self.work_dir, "bcr_staging/modules")
         self.assertIn("Version '1.0.0' was removed from 'versions' in bcr_staging/modules/existing_module/metadata.json but was not added to 'yanked_versions'.", violations)
+
+    def write_text(self, base_dir: Path, rel_path: str, content: str):
+        path = base_dir / rel_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+
+    def test_modified_module_bazel_bump_version_allowed(self):
+        rel_path = "modules/existing_module/1.0.0/MODULE.bazel"
+        old_content = """module(
+    name = "existing_module",
+    version = "1.0.0-1.rcr.1",
+)
+bazel_dep(name = "some_dep", version = "1.2.3")
+"""
+        new_content = """module(
+    name = "existing_module",
+    version = "1.0.0-1.rcr.2",
+)
+bazel_dep(name = "some_dep", version = "1.2.3")
+"""
+        self.write_text(self.old_dir, rel_path, old_content)
+        self.write_text(self.work_dir, rel_path, new_content)
+
+        diffs = [("M", rel_path)]
+        violations = check_violations(diffs, self.old_dir, self.work_dir, "modules")
+        self.assertEqual(violations, [])
+
+    def test_modified_module_bazel_other_edits_forbidden(self):
+        rel_path = "modules/existing_module/1.0.0/MODULE.bazel"
+        old_content = """module(
+    name = "existing_module",
+    version = "1.0.0-1.rcr.1",
+)
+bazel_dep(name = "some_dep", version = "1.2.3")
+"""
+        # Change a dependency version, even if version field is bumped correctly
+        new_content = """module(
+    name = "existing_module",
+    version = "1.0.0-1.rcr.2",
+)
+bazel_dep(name = "some_dep", version = "1.2.4")
+"""
+        self.write_text(self.old_dir, rel_path, old_content)
+        self.write_text(self.work_dir, rel_path, new_content)
+
+        diffs = [("M", rel_path)]
+        violations = check_violations(diffs, self.old_dir, self.work_dir, "modules")
+        self.assertIn("MODULE.bazel has modifications other than the version bump: modules/existing_module/1.0.0/MODULE.bazel", violations)
+
+    def test_modified_module_bazel_wrong_version_forbidden(self):
+        rel_path = "modules/existing_module/1.0.0/MODULE.bazel"
+        old_content = """module(
+    name = "existing_module",
+    version = "1.0.0-1.rcr.1",
+)
+"""
+        # Change version field but not to the correct next patch version
+        new_content = """module(
+    name = "existing_module",
+    version = "1.0.0-1.rcr.3",
+)
+"""
+        self.write_text(self.old_dir, rel_path, old_content)
+        self.write_text(self.work_dir, rel_path, new_content)
+
+        diffs = [("M", rel_path)]
+        violations = check_violations(diffs, self.old_dir, self.work_dir, "modules")
+        self.assertIn("MODULE.bazel version was changed from '1.0.0-1.rcr.1' to '1.0.0-1.rcr.3', but it should have been incremented to '1.0.0-1.rcr.2'.", violations)
+
+    def test_modified_module_bazel_rosdistro_allowed(self):
+        rel_path = "modules/rosdistro/lyrical.2026-06-08.rcr.1/MODULE.bazel"
+        old_content = """module(
+    name = "rosdistro",
+    version = "lyrical.2026-06-08.rcr.1",
+)
+bazel_dep(name = "some_dep", version = "1.2.3")
+"""
+        # Rosdistro can have any edits (e.g. adding dependencies, changing version, etc.)
+        new_content = """module(
+    name = "rosdistro",
+    version = "lyrical.2026-06-08.rcr.1",
+)
+bazel_dep(name = "some_dep", version = "1.2.4")
+bazel_dep(name = "new_dep", version = "2.0.0")
+"""
+        self.write_text(self.old_dir, rel_path, old_content)
+        self.write_text(self.work_dir, rel_path, new_content)
+
+        diffs = [("M", rel_path)]
+        violations = check_violations(diffs, self.old_dir, self.work_dir, "modules")
+        self.assertEqual(violations, [])
 
 
 class TestMain(unittest.TestCase):

--- a/tools/ci/create_patch.py
+++ b/tools/ci/create_patch.py
@@ -183,6 +183,7 @@ class ModuleRollup:
     new_version: str
     current_module_dir: Path
     new_module_dir: Path
+    vendor_module_dir: Path
     new_patches: Dict[str, str]
     new_overlays: Dict[str, str]
     old_patches: Dict[str, str]
@@ -190,6 +191,11 @@ class ModuleRollup:
 
     @property
     def changed(self) -> bool:
+        if self.module == "rosdistro":
+            old_module_dot_bazel = (self.current_module_dir / "MODULE.bazel").read_text()
+            new_module_dot_bazel = (self.vendor_module_dir / "MODULE.bazel").read_text()
+            if old_module_dot_bazel != new_module_dot_bazel:
+                return True
         return self.new_patches != self.old_patches or self.new_overlays != self.old_overlays
 
 
@@ -260,6 +266,7 @@ def compute_rollup(
         new_version=new_version,
         current_module_dir=current_module_dir,
         new_module_dir=new_module_dir,
+        vendor_module_dir=vendor_module_dir,
         new_patches=new_patches,
         new_overlays=new_overlays,
         old_patches=old_patches,
@@ -287,6 +294,9 @@ def apply_rollup(rollup: ModuleRollup, metadata_path: Path) -> None:
         overlay_path.write_text(content)
 
     module_file = rollup.new_module_dir / "MODULE.bazel"
+    if rollup.module == "rosdistro":
+        shutil.copy2(rollup.vendor_module_dir / "MODULE.bazel", module_file)
+
     module_file.write_text(
         bzlmod_lib.rewrite_module_version(module_file.read_text(), rollup.module, rollup.new_version)
     )

--- a/tools/ci/create_patch_test.py
+++ b/tools/ci/create_patch_test.py
@@ -389,6 +389,83 @@ class TestMainAutoDetect(_RollupFixtureTestCase):
         self.run_main(["rclcpp"])
         self.assertTrue(self.new_version_dir().exists())
 
+class TestRosdistroMODULEBazelRollup(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp_dir = Path(tempfile.mkdtemp())
+        self.workspace_root = self.tmp_dir / "repo"
+        self.modules_dir = self.workspace_root / "modules"
+        self.target_workspace = self.workspace_root / "workspace"
+        (self.target_workspace / "vendor").mkdir(parents=True)
+        (self.target_workspace / "MODULE.bazel").write_text("")
+
+        module_dir = self.modules_dir / "rosdistro"
+        self.version_dir = module_dir / "lyrical.2026-06-08.rcr.1"
+        self.version_dir.mkdir(parents=True)
+        with open(module_dir / "metadata.json", "w") as f:
+            json.dump({"versions": ["lyrical.2026-06-08.rcr.1"], "yanked_versions": {}}, f)
+        
+        self.old_module_content = (
+            'module(\n'
+            '    name = "rosdistro",\n'
+            '    version = "lyrical.2026-06-08.rcr.1",\n'
+            ')\n'
+            'bazel_dep(name = "old_dep", version = "1.0.0")\n'
+        )
+        (self.version_dir / "MODULE.bazel").write_text(self.old_module_content)
+
+        # source.json has to exist for compute_rollup to load pristine/raw-upstream
+        # even though we don't have diffs.
+        archive_src = self.tmp_dir / "archive_src" / "rosdistro-lyrical-2026-06-08"
+        archive_src.mkdir(parents=True)
+        (archive_src / "dummy.txt").write_text("hello\n")
+        archive_path = self.tmp_dir / "rosdistro.tar.gz"
+        with tarfile.open(archive_path, "w:gz") as tf:
+            tf.add(archive_src, arcname="rosdistro-lyrical-2026-06-08")
+        
+        digest = base64.b64encode(hashlib.sha256(archive_path.read_bytes()).digest()).decode()
+        with open(self.version_dir / "source.json", "w") as f:
+            json.dump({
+                "url": archive_path.as_uri(),
+                "strip_prefix": "rosdistro-lyrical-2026-06-08",
+                "integrity": f"sha256-{digest}",
+            }, f)
+
+        self.vendor_module_dir = self.target_workspace / "vendor" / "rosdistro+"
+        self.vendor_module_dir.mkdir(parents=True)
+        # In vendor_module_dir, write the dummy.txt as well so no diffs in source files
+        (self.vendor_module_dir / "dummy.txt").write_text("hello\n")
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp_dir)
+
+    def test_rosdistro_module_bazel_edits_detected_and_applied(self):
+        # Developer edits MODULE.bazel in vendored tree (adds a new dependency)
+        new_module_content = (
+            'module(\n'
+            '    name = "rosdistro",\n'
+            '    version = "lyrical.2026-06-08.rcr.1",\n'
+            ')\n'
+            'bazel_dep(name = "old_dep", version = "1.0.0")\n'
+            'bazel_dep(name = "new_dep", version = "2.0.0")\n'
+        )
+        (self.vendor_module_dir / "MODULE.bazel").write_text(new_module_content)
+
+        rollup = create_patch.compute_rollup("rosdistro", self.modules_dir, self.target_workspace)
+        self.assertTrue(rollup.changed)
+        self.assertEqual(rollup.current_version, "lyrical.2026-06-08.rcr.1")
+        self.assertEqual(rollup.new_version, "lyrical.2026-06-08.rcr.2")
+
+        create_patch.apply_rollup(rollup, self.modules_dir / "rosdistro" / "metadata.json")
+
+        new_dir = self.modules_dir / "rosdistro" / "lyrical.2026-06-08.rcr.2"
+        self.assertTrue(new_dir.exists())
+        
+        # Verify the new MODULE.bazel has the developer's modifications AND the correct new version
+        new_content = (new_dir / "MODULE.bazel").read_text()
+        self.assertIn('version = "lyrical.2026-06-08.rcr.2"', new_content)
+        self.assertIn('bazel_dep(name = "new_dep", version = "2.0.0")', new_content)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/ci/setup_workspace.py
+++ b/tools/ci/setup_workspace.py
@@ -317,7 +317,7 @@ def main():
     # version so this workspace is never stale -- this is what keeps
     # concurrent per-package patches from colliding on the same next
     # version number (see docs/source/design_choices.rst).
-    override_candidates = {k: v for k, v in packages.items() if k not in ("ros", "rosdistro")}
+    override_candidates = {k: v for k, v in packages.items() if k not in ("ros")}
     overrides = find_packages_with_newer_versions(override_candidates, modules_dir)
     for name, latest_version in sorted(overrides.items()):
         print(


### PR DESCRIPTION
## Summary

Adds some information to `AGENTS.md` and `.agents` to make editing modules a little more reliable when using LLMs. I relaxed the CI check that the `MODULE.bazel` file for `rosdistro` cannot be edited, while enforcing this is the case for all other modules. I also fixed some vendoring logic that prevented rosdistro from being initialized with `single_version_override` in a new workspace, which was causing issues with repeatability. I also removed the "packages affected" section from the PR template because it's obvious from the diff.

## Acknowledgements

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Code of Conduct](../CODE_OF_CONDUCT.md) and agree to abide by it.
- [x] I have read and complied with the [OSRF Policy on the Use of Generative AI Tools ("Generative AI") in Contributions](https://github.com/openrobotics/osra-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md).

## Generative AI disclosure

Yes, I used Claude to help identify the source of the issues.