### PR TITLE
Fix bootstrap generator's buildifier bug

### DIFF
--- a/tools/ci/bootstrap_release.py
+++ b/tools/ci/bootstrap_release.py
@@ -81,6 +81,7 @@ qt.install(
     version = "6.8.3",
 )
 use_repo(qt, "qt_linux_x86_64")
+
 register_toolchains("@rules_qt//tools:all")
 """
 
@@ -159,6 +160,7 @@ qt.install(
     version = "6.8.3",
 )
 use_repo(qt, "qt_linux_x86_64")
+
 register_toolchains("@rules_qt//tools:all")
 """
 

--- a/tools/ci/bootstrap_release_test.py
+++ b/tools/ci/bootstrap_release_test.py
@@ -107,6 +107,18 @@ class TestRenderModuleDotBazel(unittest.TestCase):
         self.assertIn('bazel_dep(name = "assimp", version = "6.0.3")', content)
         self.assertIn('hub_name = "pip_ros"', content)
 
+    def test_trailing_register_toolchains_is_buildifier_formatted(self):
+        # buildifier requires a blank line before a bare statement that
+        # follows a use_repo(...) call -- regression test for a bug where
+        # every bootstrapped MODULE.bazel failed lint (see git history).
+        for content in (
+                bootstrap_release.render_module_dot_bazel(
+                    "rclcpp", "32.0.0-1", {}, "lyrical", "2026-06-23"),
+                bootstrap_release.render_module_dot_bazel(
+                    "rosdistro", "lyrical.2026-06-23", {}, "lyrical", "2026-06-23",
+                    custom_body=bootstrap_release.ROSDISTRO_CUSTOM_BODY)):
+            self.assertIn('use_repo(qt, "qt_linux_x86_64")\n\nregister_toolchains("@rules_qt//tools:all")', content)
+
 
 class TestRenderStubModuleDotBazel(unittest.TestCase):
 


### PR DESCRIPTION
## Summary

Root cause of a buildifier-failing bootstrap commit found during this session: `bootstrap_release.py`'s two `MODULE.bazel` templates (`BOOTSTRAP_TRAILER`, used for every package, and `ROSDISTRO_CUSTOM_BODY`, used only for `rosdistro`) were both missing a blank line before the trailing `register_toolchains(...)` call -- buildifier requires one before a bare statement following a `use_repo(...)` call. This wasn't a one-off: confirmed via `buildifier -mode diff` that this was the *exact same* single-line diff on every one of the ~180 packages a real bootstrap run touched.

Fixes the generator and adds a regression test asserting the blank line survives in both templates' rendered output.

(The bootstrap run that surfaced this bug has since been discarded via a `main` history reset, so this PR is now just the generator fix -- no packages need reformatting.)

## Acknowledgements

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Code of Conduct](../CODE_OF_CONDUCT.md) and agree to abide by it.
- [x] I have read and complied with the [OSRF Policy on the Use of Generative AI Tools ("Generative AI") in Contributions](https://github.com/openrobotics/osra-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md).

## Generative AI disclosure

- Was any generative AI tool used in this contribution? Yes.
- If yes, which tool(s), and for which part(s) of the contribution? Claude (Sonnet 5) authored this entire fix interactively, including diagnosing the root cause via `buildifier -mode diff` across the affected packages.

## Related issue(s)

- Fixes: N/A -- prompted by a buildifier-failing bootstrap run found during this session.

## Additional information

Worth merging before the next scheduled `nightly_bootstrap` run (08:00 UTC daily) to avoid regenerating the same lint failure.
