### PR TITLE
Add Claude Code GitHub Actions for issue implementation and interactive follow-up

### DIFF
--- a/.github/workflows/claude_interactive.yml
+++ b/.github/workflows/claude_interactive.yml
@@ -73,7 +73,7 @@ jobs:
       uses: anthropics/claude-code-action@v1
       with:
         claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-        show_full_output: true
+        show_full_output: false
         claude_args: |
           --max-turns 80
           --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git:*),Bash(gh:*),Bash(bazel:*)"

--- a/.github/workflows/claude_interactive.yml
+++ b/.github/workflows/claude_interactive.yml
@@ -75,17 +75,30 @@ jobs:
         claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         show_full_output: true
         claude_args: |
-          --max-turns 40
+          --max-turns 80
           --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git:*),Bash(gh:*),Bash(bazel:*)"
           --append-system-prompt "Read AGENTS.md at the repo root and
           follow it exactly, including using the
           setup-workspace/vendor-module/create-patch skills in
           .agent/skills/ to patch anything under modules/ (never hand-edit
           files under modules/<pkg>/<version>/, never modify or delete an
-          existing version directory). Sign off every commit with git
-          commit -s per the DCO requirement in CONTRIBUTING.md. If you
-          open or update a pull request, use
-          .github/PULL_REQUEST_TEMPLATE.md and fill out every section
-          honestly, including a truthful Generative AI disclosure per the
-          OSRF policy it links. Never merge, approve, or request review on
-          a pull request yourself."
+          existing version directory). Work efficiently: before writing new
+          Bazel content, find an existing, already-implemented package with
+          a similar shape and mirror its structure rather than inventing
+          one from scratch, and don't spend turns hand-exploring the runner
+          environment or hand-rolling registry checks (e.g. curl against
+          bcr.bazel.build) -- attempt the real bazel command and read its
+          own error messages instead. Checkpoint real progress via
+          create-patch at natural milestones as you go, not only at the
+          end, since re-vendoring a package with uncommitted edits discards
+          them (see AGENTS.md). Sign off every commit with git commit -s
+          per the DCO requirement in CONTRIBUTING.md. If you open or update
+          a pull request, use .github/PULL_REQUEST_TEMPLATE.md and fill out
+          every section honestly, including a truthful Generative AI
+          disclosure per the OSRF policy it links. Never merge, approve, or
+          request review on a pull request yourself. If a request turns out
+          to be too large for one PR (e.g. porting a bundled third-party
+          SDK, or a dependency missing from the Bazel Central Registry
+          entirely), don't brute-force it to completion -- say so, explain
+          the real scope, and propose splitting it into smaller pieces
+          instead of running out of turns mid-attempt."

--- a/.github/workflows/claude_interactive.yml
+++ b/.github/workflows/claude_interactive.yml
@@ -1,0 +1,91 @@
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Interactive companion to claude_issue_implement.yml. Mention "@claude" in an
+# issue, a PR comment, or a PR review (including on PRs Claude itself opened)
+# and it responds or pushes follow-up commits addressing the feedback. Like
+# the auto-implement workflow, the action only acts for users with write
+# access to the repo, so only a maintainer's "@claude" mention triggers it —
+# but the surrounding comment/issue thread is still untrusted content from
+# whoever wrote it, so skim before relying on Claude's response.
+
+name: claude-interactive
+
+run-name: Respond to @claude mention
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned]
+
+concurrency:
+  group: claude-interactive-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+  actions: read # lets Claude read CI results on the PR it's responding in
+
+jobs:
+  claude:
+    name: Respond to @claude
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v7
+      with:
+        fetch-depth: 1
+
+    - name: Setup Bazel
+      uses: bazel-contrib/setup-bazel@0.19.0
+      with:
+        bazelisk-cache: true
+        disk-cache: false
+        repository-cache: true
+
+    - name: Run Claude Code
+      id: claude
+      uses: anthropics/claude-code-action@v1
+      with:
+        claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        show_full_output: true
+        claude_args: |
+          --max-turns 40
+          --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git:*),Bash(gh:*),Bash(bazel:*)"
+          --append-system-prompt "Read AGENTS.md at the repo root and
+          follow it exactly, including using the
+          setup-workspace/vendor-module/create-patch skills in
+          .agent/skills/ to patch anything under modules/ (never hand-edit
+          files under modules/<pkg>/<version>/, never modify or delete an
+          existing version directory). Sign off every commit with git
+          commit -s per the DCO requirement in CONTRIBUTING.md. If you
+          open or update a pull request, use
+          .github/PULL_REQUEST_TEMPLATE.md and fill out every section
+          honestly, including a truthful Generative AI disclosure per the
+          OSRF policy it links. Never merge, approve, or request review on
+          a pull request yourself."

--- a/.github/workflows/claude_issue_implement.yml
+++ b/.github/workflows/claude_issue_implement.yml
@@ -1,0 +1,121 @@
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Triggered by applying the "claude-implement" label to an issue. Claude reads
+# the issue, implements a fix following CONTRIBUTING.md, and opens a PR for
+# human review — it never merges anything itself. Since the action only acts
+# for users with write access to the repo, only a maintainer applying the
+# label can trigger a run; the issue body itself is still untrusted content
+# (see .github/workflows/claude_issue_implement.yml review notes / Anthropic's
+# prompt-injection guidance), so skim an issue before labeling it.
+
+name: claude-issue-implement
+
+run-name: Implement issue #${{ github.event.issue.number }} with Claude
+
+on:
+  issues:
+    types: [labeled]
+
+concurrency:
+  group: claude-issue-implement-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write # required so the action can fetch a GitHub OIDC token
+
+jobs:
+  implement:
+    name: Implement issue and open PR
+    if: github.event.label.name == 'claude-implement'
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+
+    - name: Setup Bazel
+      uses: bazel-contrib/setup-bazel@0.19.0
+      with:
+        bazelisk-cache: true
+        disk-cache: false
+        repository-cache: true
+
+    - name: Setup git identity
+      run: |
+        git config --global user.email "claude[bot]@users.noreply.github.com"
+        git config --global user.name "claude[bot]"
+
+    - name: Create implementation branch
+      id: branch
+      run: |
+        BRANCH_NAME="claude/issue-${{ github.event.issue.number }}"
+        git checkout -b "$BRANCH_NAME"
+        echo "branch_name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
+
+    - name: Implement issue with Claude
+      uses: anthropics/claude-code-action@v1
+      with:
+        claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        show_full_output: true
+        prompt: |
+          REPO: ${{ github.repository }}
+          ISSUE NUMBER: ${{ github.event.issue.number }}
+          ISSUE TITLE: ${{ github.event.issue.title }}
+          ISSUE AUTHOR: ${{ github.event.issue.user.login }}
+          BRANCH: ${{ steps.branch.outputs.branch_name }}
+
+          ISSUE BODY:
+          ${{ github.event.issue.body }}
+
+          First, read AGENTS.md at the repo root in full — it's the mandatory
+          guidance for coding agents in this repository, including the
+          setup-workspace / vendor-module / create-patch skill pipeline in
+          .agent/skills/ for patching packages under modules/, plus linting,
+          licensing, and testing conventions. Follow it exactly, and use
+          those skills rather than hand-editing anything under modules/ or
+          hand-rolling `bazel run //tools/ci:...` invocations yourself.
+
+          Then implement this issue on the current branch and open a pull
+          request for human review:
+
+          - Run the relevant fast local checks (buildifier, ruff, and any
+            targeted test for what you touched — see the Linting section of
+            AGENTS.md) before committing. Do not attempt a full distribution
+            build; .github/workflows/ci.yaml already does that comprehensively
+            on the PR.
+          - Sign off every commit (`git commit -s`) per the DCO requirement in
+            CONTRIBUTING.md, using the claude[bot] identity already configured
+            in this job.
+          - Push the branch, then open the PR against main with `gh pr create`.
+            Use .github/PULL_REQUEST_TEMPLATE.md as the PR body verbatim,
+            filling out every section honestly — in particular, answer the
+            Generative AI disclosure truthfully (you are Claude; say so and
+            describe what you did) per the OSRF Generative AI policy it
+            links, and put "Fixes #${{ github.event.issue.number }}" under
+            Related issue(s). Title the PR clearly, and leave it open for
+            @${{ github.repository_owner }} to review — do not merge it,
+            approve it, or request review from anyone yourself.
+          - If the issue is too vague or under-specified to implement safely,
+            do not guess or implement something speculative: instead run
+            `gh issue comment` explaining what clarification you need, and do
+            not open a PR.
+        claude_args: |
+          --max-turns 80
+          --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git:*),Bash(gh:*),Bash(bazel:*)"

--- a/.github/workflows/claude_issue_implement.yml
+++ b/.github/workflows/claude_issue_implement.yml
@@ -95,6 +95,23 @@ jobs:
           Then implement this issue on the current branch and open a pull
           request for human review:
 
+          - Work efficiently: before writing any new Bazel content, find an
+            existing, already-implemented package in modules/ with a similar
+            shape (e.g. another message-only package, another driver with
+            ROS2 components) and mirror its exact structure rather than
+            inventing one from scratch — this is far faster and more likely
+            to be correct than guessing. Don't spend turns hand-exploring the
+            runner environment (system paths, global config files) or
+            hand-rolling registry checks (e.g. curl against bcr.bazel.build)
+            to verify a dependency exists — just attempt the real
+            bazel build/create-patch command and read Bazel's own error
+            messages, which are authoritative and faster than guessing.
+          - Checkpoint real progress via the create-patch skill at natural
+            milestones as you go, not only at the very end — this protects
+            against losing work (re-vendoring a package with uncommitted
+            edits discards them, see AGENTS.md) and means a partial,
+            genuinely useful PR exists even if you run out of turns before
+            finishing everything.
           - Run the relevant fast local checks (buildifier, ruff, and any
             targeted test for what you touched — see the Linting section of
             AGENTS.md) before committing. Do not attempt a full distribution
@@ -116,6 +133,21 @@ jobs:
             do not guess or implement something speculative: instead run
             `gh issue comment` explaining what clarification you need, and do
             not open a PR.
+          - If the issue is well-specified but genuinely too large for one PR
+            (e.g. it would require porting a bundled third-party SDK spanning
+            tens of thousands of lines, or authoring a brand-new Bazel module
+            from scratch for a dependency that doesn't exist in the Bazel
+            Central Registry at all), don't try to brute-force a complete
+            implementation — you will run out of turns before finishing and
+            waste the run. Instead, do enough investigation to describe the
+            real scope (what's actually needed vs. what looked scary at
+            first glance — see AGENTS.md's guidance on checking the
+            consuming package's build options before assuming a bundled
+            dependency is required), then `gh issue comment` proposing how to
+            split it into smaller, independently-mergeable issues, and open
+            a PR only for whatever well-scoped first slice you did manage to
+            finish (if any) rather than an incomplete attempt at the whole
+            thing.
         claude_args: |
-          --max-turns 80
+          --max-turns 200
           --allowedTools "Edit,MultiEdit,Write,Read,Glob,Grep,LS,Bash(git:*),Bash(gh:*),Bash(bazel:*)"

--- a/.github/workflows/claude_issue_implement.yml
+++ b/.github/workflows/claude_issue_implement.yml
@@ -73,7 +73,7 @@ jobs:
       uses: anthropics/claude-code-action@v1
       with:
         claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-        show_full_output: true
+        show_full_output: false
         prompt: |
           REPO: ${{ github.repository }}
           ISSUE NUMBER: ${{ github.event.issue.number }}


### PR DESCRIPTION
## Summary

Adds two GitHub Actions workflows built on [anthropics/claude-code-action](https://github.com/anthropics/claude-code-action):

- **`claude_issue_implement.yml`**: applying the `claude-implement` label to an issue has Claude read it, implement a fix following this repo's `AGENTS.md`/`CONTRIBUTING.md` conventions, and open a PR for human review -- it never merges or approves anything itself. Includes a guardrail instructing it to recognize genuinely oversized issues (e.g. one requiring porting a bundled third-party SDK, or a dependency missing from the Bazel Central Registry entirely) and propose splitting them into smaller issues rather than trying to brute-force a complete implementation and running out of turns mid-attempt.
- **`claude_interactive.yml`**: `@claude` mentions in issue comments, PR comments, and PR reviews get an interactive response -- including pushing follow-up commits directly to PRs (including ones Claude itself opened) rather than just replying.

Both are gated on the action's own actor-permission check (only users with write access to the repo can trigger them -- the untrusted part of an issue/comment is still its *content*, so labeling/mentioning is the human review checkpoint), require a `CLAUDE_CODE_OAUTH_TOKEN` repository secret to function, and are instructed to follow this repo's `PULL_REQUEST_TEMPLATE.md` (including an honest Generative AI disclosure per the linked OSRF policy) and DCO sign-off requirement on every commit.

## Acknowledgements

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Code of Conduct](../CODE_OF_CONDUCT.md) and agree to abide by it.
- [x] I have read and complied with the [OSRF Policy on the Use of Generative AI Tools ("Generative AI") in Contributions](https://github.com/openrobotics/osra-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md).

## Generative AI disclosure

- Was any generative AI tool used in this contribution? Yes.
- If yes, which tool(s), and for which part(s) of the contribution? Claude (Sonnet 5) authored, debugged, and iterated on both workflows interactively across a full session including live GitHub Actions runs.

## Related issue(s)

- Fixes: N/A -- new tooling.

## Additional information

Requires the `CLAUDE_CODE_OAUTH_TOKEN` repository secret to be set (generate via `claude setup-token` locally, then `gh secret set CLAUDE_CODE_OAUTH_TOKEN`) and the `claude-implement` label to exist on the repo before `claude_issue_implement.yml` can be used.
