### PR TITLE
Make CI fork-safe: opt-in remote cache writes, gate badges/RCR-UI notify to upstream

### DIFF
--- a/.github/workflows/_check_bazel_modules.yml
+++ b/.github/workflows/_check_bazel_modules.yml
@@ -141,4 +141,4 @@ jobs:
         label: modules
         message: ${{ job.status == 'success' && '✓' || 'x' }}
         color: ${{ job.status == 'success' && 'green' || 'red' }}
-      if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push'
+      if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push' && github.repository == 'intrinsic-opensource/ros-central-registry'

--- a/.github/workflows/_check_bazel_modules.yml
+++ b/.github/workflows/_check_bazel_modules.yml
@@ -141,4 +141,4 @@ jobs:
         label: modules
         message: ${{ job.status == 'success' && '✓' || 'x' }}
         color: ${{ job.status == 'success' && 'green' || 'red' }}
-      if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push' && github.repository == 'intrinsic-opensource/ros-central-registry'
+      if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push' && (github.event.pull_request.head.repo.full_name || github.repository) == 'intrinsic-opensource/ros-central-registry'

--- a/.github/workflows/_check_distribution_compiles.yml
+++ b/.github/workflows/_check_distribution_compiles.yml
@@ -73,8 +73,13 @@ jobs:
         fetch-depth: 1
         ref: ${{ inputs.branch }}
 
-    # Setup auth to allow pushing to the remote cache.
+    # Setup auth to allow pushing to the remote cache. The WIF trust policy
+    # only covers the upstream repo -- this (and --remote-cache-write below)
+    # is skipped on forks, which fall back to the default config's
+    # anonymous, read-only cache access rather than failing when a write
+    # is attempted with no valid credentials.
     - name: Authenticate to Google Cloud
+      if: github.repository == 'intrinsic-opensource/ros-central-registry'
       uses: "google-github-actions/auth@v3"
       with:
         workload_identity_provider: projects/771457463613/locations/global/workloadIdentityPools/github-automation/providers/build-dev
@@ -94,7 +99,8 @@ jobs:
       id: prepare_workspace
       working-directory: .
       run: |
-        bazel run //tools/ci:setup_workspace -- --release=${{ matrix.ros }} --tmpdir "$RUNNER_TEMP"
+        bazel run //tools/ci:setup_workspace -- --release=${{ matrix.ros }} --tmpdir "$RUNNER_TEMP" \
+            ${{ github.repository == 'intrinsic-opensource/ros-central-registry' && '--remote-cache-write' || '' }}
 
     # Build the ros 2 distribution
     - name: Build

--- a/.github/workflows/_check_distribution_compiles.yml
+++ b/.github/workflows/_check_distribution_compiles.yml
@@ -116,7 +116,7 @@ jobs:
         label: ${{ matrix.bazel }}
         message: ${{ steps.build.outcome == 'success' && '✓' || 'x' }}
         color: ${{ steps.build.outcome == 'success' && 'green' || 'red' }}
-      if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push'
+      if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push' && github.repository == 'intrinsic-opensource/ros-central-registry'
 
     - name: Compile logs
       uses: actions/upload-artifact@v7

--- a/.github/workflows/_check_distribution_compiles.yml
+++ b/.github/workflows/_check_distribution_compiles.yml
@@ -79,7 +79,7 @@ jobs:
     # anonymous, read-only cache access rather than failing when a write
     # is attempted with no valid credentials.
     - name: Authenticate to Google Cloud
-      if: github.repository == 'intrinsic-opensource/ros-central-registry'
+      if: (github.event.pull_request.head.repo.full_name || github.repository) == 'intrinsic-opensource/ros-central-registry'
       uses: "google-github-actions/auth@v3"
       with:
         workload_identity_provider: projects/771457463613/locations/global/workloadIdentityPools/github-automation/providers/build-dev
@@ -100,7 +100,7 @@ jobs:
       working-directory: .
       run: |
         bazel run //tools/ci:setup_workspace -- --release=${{ matrix.ros }} --tmpdir "$RUNNER_TEMP" \
-            ${{ github.repository == 'intrinsic-opensource/ros-central-registry' && '--remote-cache-write' || '' }}
+            ${{ (github.event.pull_request.head.repo.full_name || github.repository) == 'intrinsic-opensource/ros-central-registry' && '--remote-cache-write' || '' }}
 
     # Build the ros 2 distribution
     - name: Build
@@ -116,7 +116,7 @@ jobs:
         label: ${{ matrix.bazel }}
         message: ${{ steps.build.outcome == 'success' && '✓' || 'x' }}
         color: ${{ steps.build.outcome == 'success' && 'green' || 'red' }}
-      if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push' && github.repository == 'intrinsic-opensource/ros-central-registry'
+      if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push' && (github.event.pull_request.head.repo.full_name || github.repository) == 'intrinsic-opensource/ros-central-registry'
 
     - name: Compile logs
       uses: actions/upload-artifact@v7

--- a/.github/workflows/_check_distribution_examples.yml
+++ b/.github/workflows/_check_distribution_examples.yml
@@ -79,7 +79,7 @@ jobs:
     # default anonymous, read-only cache access rather than failing when a
     # write is attempted with no valid credentials.
     - name: Authenticate to Google Cloud
-      if: github.repository == 'intrinsic-opensource/ros-central-registry'
+      if: (github.event.pull_request.head.repo.full_name || github.repository) == 'intrinsic-opensource/ros-central-registry'
       uses: "google-github-actions/auth@v3"
       with:
         workload_identity_provider: projects/771457463613/locations/global/workloadIdentityPools/github-automation/providers/build-dev
@@ -100,7 +100,7 @@ jobs:
       working-directory: ./examples
       run: |
         export TMPDIR="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
-        CACHE_WRITE_CONFIG="${{ github.repository == 'intrinsic-opensource/ros-central-registry' && '--config=ci-cache-write' || '' }}"
+        CACHE_WRITE_CONFIG="${{ (github.event.pull_request.head.repo.full_name || github.repository) == 'intrinsic-opensource/ros-central-registry' && '--config=ci-cache-write' || '' }}"
         bazel build --config ci $CACHE_WRITE_CONFIG //... 2>&1 | tee examples_dynamic.log
         bazel build --config ci $CACHE_WRITE_CONFIG --dynamic_mode=off --@rosdistro//:rmw=rmw_fastrtps_cpp //:example_ros_publisher_cc 2>&1 | tee examples_static_rmw_fastrtps_cpp.log
         bazel build --config ci $CACHE_WRITE_CONFIG --dynamic_mode=off --@rosdistro//:rmw=rmw_fastrtps_dynamic_cpp //:example_ros_publisher_cc 2>&1 | tee examples_static_rmw_fastrtps_dynamic_cpp.log
@@ -115,7 +115,7 @@ jobs:
         label: ${{ matrix.bazel }}
         message: ${{ steps.examples.outcome == 'success' && '✓' || 'x' }}
         color: ${{ steps.examples.outcome == 'success' && 'green' || 'red' }}
-      if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push' && github.repository == 'intrinsic-opensource/ros-central-registry'
+      if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push' && (github.event.pull_request.head.repo.full_name || github.repository) == 'intrinsic-opensource/ros-central-registry'
 
     - name: Example logs
       uses: actions/upload-artifact@v7

--- a/.github/workflows/_check_distribution_examples.yml
+++ b/.github/workflows/_check_distribution_examples.yml
@@ -73,8 +73,13 @@ jobs:
         fetch-depth: 1
         ref: ${{ inputs.branch }}
 
-    # Setup auth to allow pushing to the remote cache.
+    # Setup auth to allow pushing to the remote cache. The WIF trust policy
+    # only covers the upstream repo -- this (and --config=ci-cache-write
+    # below) is skipped on forks, which fall back to examples/.bazelrc's
+    # default anonymous, read-only cache access rather than failing when a
+    # write is attempted with no valid credentials.
     - name: Authenticate to Google Cloud
+      if: github.repository == 'intrinsic-opensource/ros-central-registry'
       uses: "google-github-actions/auth@v3"
       with:
         workload_identity_provider: projects/771457463613/locations/global/workloadIdentityPools/github-automation/providers/build-dev
@@ -95,11 +100,12 @@ jobs:
       working-directory: ./examples
       run: |
         export TMPDIR="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
-        bazel build --config ci //... 2>&1 | tee examples_dynamic.log
-        bazel build --config ci --dynamic_mode=off --@rosdistro//:rmw=rmw_fastrtps_cpp //:example_ros_publisher_cc 2>&1 | tee examples_static_rmw_fastrtps_cpp.log
-        bazel build --config ci --dynamic_mode=off --@rosdistro//:rmw=rmw_fastrtps_dynamic_cpp //:example_ros_publisher_cc 2>&1 | tee examples_static_rmw_fastrtps_dynamic_cpp.log
-        bazel build --config ci --dynamic_mode=off --@rosdistro//:rmw=rmw_cyclonedds_cpp //:example_ros_publisher_cc 2>&1 | tee examples_static_rmw_cyclonedds_cpp.log
-        bazel build --config ci --dynamic_mode=off --@rosdistro//:rmw=rmw_zenoh_cpp //:example_ros_publisher_cc 2>&1 | tee examples_static_rmw_zenoh_cpp.log
+        CACHE_WRITE_CONFIG="${{ github.repository == 'intrinsic-opensource/ros-central-registry' && '--config=ci-cache-write' || '' }}"
+        bazel build --config ci $CACHE_WRITE_CONFIG //... 2>&1 | tee examples_dynamic.log
+        bazel build --config ci $CACHE_WRITE_CONFIG --dynamic_mode=off --@rosdistro//:rmw=rmw_fastrtps_cpp //:example_ros_publisher_cc 2>&1 | tee examples_static_rmw_fastrtps_cpp.log
+        bazel build --config ci $CACHE_WRITE_CONFIG --dynamic_mode=off --@rosdistro//:rmw=rmw_fastrtps_dynamic_cpp //:example_ros_publisher_cc 2>&1 | tee examples_static_rmw_fastrtps_dynamic_cpp.log
+        bazel build --config ci $CACHE_WRITE_CONFIG --dynamic_mode=off --@rosdistro//:rmw=rmw_cyclonedds_cpp //:example_ros_publisher_cc 2>&1 | tee examples_static_rmw_cyclonedds_cpp.log
+        bazel build --config ci $CACHE_WRITE_CONFIG --dynamic_mode=off --@rosdistro//:rmw=rmw_zenoh_cpp //:example_ros_publisher_cc 2>&1 | tee examples_static_rmw_zenoh_cpp.log
     - name: Update status badge (examples)
       uses: Schneegans/dynamic-badges-action@v1.8.0
       with:

--- a/.github/workflows/_check_distribution_examples.yml
+++ b/.github/workflows/_check_distribution_examples.yml
@@ -115,7 +115,7 @@ jobs:
         label: ${{ matrix.bazel }}
         message: ${{ steps.examples.outcome == 'success' && '✓' || 'x' }}
         color: ${{ steps.examples.outcome == 'success' && 'green' || 'red' }}
-      if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push'
+      if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push' && github.repository == 'intrinsic-opensource/ros-central-registry'
 
     - name: Example logs
       uses: actions/upload-artifact@v7

--- a/.github/workflows/_check_distribution_tests.yml
+++ b/.github/workflows/_check_distribution_tests.yml
@@ -77,8 +77,13 @@ jobs:
         fetch-depth: 1
         ref: ${{ inputs.branch }}
 
-    # Setup auth to allow pushing to the remote cache.
+    # Setup auth to allow pushing to the remote cache. The WIF trust policy
+    # only covers the upstream repo -- this (and --remote-cache-write below)
+    # is skipped on forks, which fall back to the default config's
+    # anonymous, read-only cache access rather than failing when a write
+    # is attempted with no valid credentials.
     - name: Authenticate to Google Cloud
+      if: github.repository == 'intrinsic-opensource/ros-central-registry'
       uses: "google-github-actions/auth@v3"
       with:
         workload_identity_provider: projects/771457463613/locations/global/workloadIdentityPools/github-automation/providers/build-dev
@@ -98,7 +103,8 @@ jobs:
       id: prepare_workspace
       working-directory: .
       run: |
-        bazel run //tools/ci:setup_workspace -- --release=${{ matrix.ros }} --tmpdir "$RUNNER_TEMP"
+        bazel run //tools/ci:setup_workspace -- --release=${{ matrix.ros }} --tmpdir "$RUNNER_TEMP" \
+            ${{ github.repository == 'intrinsic-opensource/ros-central-registry' && '--remote-cache-write' || '' }}
 
     # Run the distribution test for the implementation.
     - name: Test (${{ inputs.rmw }})

--- a/.github/workflows/_check_distribution_tests.yml
+++ b/.github/workflows/_check_distribution_tests.yml
@@ -165,7 +165,7 @@ jobs:
         label: ${{ matrix.bazel }}
         message: ${{ steps.test.outcome == 'success' && '✓' || 'x' }}
         color: ${{ steps.test.outcome == 'success' && 'green' || 'red' }}
-      if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push'
+      if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push' && github.repository == 'intrinsic-opensource/ros-central-registry'
 
     - name: Test logs
       uses: actions/upload-artifact@v7

--- a/.github/workflows/_check_distribution_tests.yml
+++ b/.github/workflows/_check_distribution_tests.yml
@@ -83,7 +83,7 @@ jobs:
     # anonymous, read-only cache access rather than failing when a write
     # is attempted with no valid credentials.
     - name: Authenticate to Google Cloud
-      if: github.repository == 'intrinsic-opensource/ros-central-registry'
+      if: (github.event.pull_request.head.repo.full_name || github.repository) == 'intrinsic-opensource/ros-central-registry'
       uses: "google-github-actions/auth@v3"
       with:
         workload_identity_provider: projects/771457463613/locations/global/workloadIdentityPools/github-automation/providers/build-dev
@@ -104,7 +104,7 @@ jobs:
       working-directory: .
       run: |
         bazel run //tools/ci:setup_workspace -- --release=${{ matrix.ros }} --tmpdir "$RUNNER_TEMP" \
-            ${{ github.repository == 'intrinsic-opensource/ros-central-registry' && '--remote-cache-write' || '' }}
+            ${{ (github.event.pull_request.head.repo.full_name || github.repository) == 'intrinsic-opensource/ros-central-registry' && '--remote-cache-write' || '' }}
 
     # Run the distribution test for the implementation.
     - name: Test (${{ inputs.rmw }})
@@ -165,7 +165,7 @@ jobs:
         label: ${{ matrix.bazel }}
         message: ${{ steps.test.outcome == 'success' && '✓' || 'x' }}
         color: ${{ steps.test.outcome == 'success' && 'green' || 'red' }}
-      if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push' && github.repository == 'intrinsic-opensource/ros-central-registry'
+      if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push' && (github.event.pull_request.head.repo.full_name || github.repository) == 'intrinsic-opensource/ros-central-registry'
 
     - name: Test logs
       uses: actions/upload-artifact@v7

--- a/.github/workflows/_check_docs_build.yml
+++ b/.github/workflows/_check_docs_build.yml
@@ -52,4 +52,4 @@ jobs:
         label: docs build
         message: ${{ job.status == 'success' && '✓' || 'x' }}
         color: ${{ job.status == 'success' && 'green' || 'red' }}
-      if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push' && github.repository == 'intrinsic-opensource/ros-central-registry'
+      if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push' && (github.event.pull_request.head.repo.full_name || github.repository) == 'intrinsic-opensource/ros-central-registry'

--- a/.github/workflows/_check_docs_build.yml
+++ b/.github/workflows/_check_docs_build.yml
@@ -52,4 +52,4 @@ jobs:
         label: docs build
         message: ${{ job.status == 'success' && '✓' || 'x' }}
         color: ${{ job.status == 'success' && 'green' || 'red' }}
-      if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push'
+      if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push' && github.repository == 'intrinsic-opensource/ros-central-registry'

--- a/.github/workflows/_check_for_linting_errors.yml
+++ b/.github/workflows/_check_for_linting_errors.yml
@@ -50,7 +50,7 @@ jobs:
         label: linting
         message: ${{ job.status == 'success' && '✓' || 'x' }}
         color: ${{ job.status == 'success' && 'green' || 'red' }}
-      if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push' && github.repository == 'intrinsic-opensource/ros-central-registry'
+      if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push' && (github.event.pull_request.head.repo.full_name || github.repository) == 'intrinsic-opensource/ros-central-registry'
 
   check_python_linting:
     name: Lint all Python files
@@ -77,4 +77,4 @@ jobs:
         label: python linting
         message: ${{ job.status == 'success' && '✓' || 'x' }}
         color: ${{ job.status == 'success' && 'green' || 'red' }}
-      if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push' && github.repository == 'intrinsic-opensource/ros-central-registry'
+      if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push' && (github.event.pull_request.head.repo.full_name || github.repository) == 'intrinsic-opensource/ros-central-registry'

--- a/.github/workflows/_check_for_linting_errors.yml
+++ b/.github/workflows/_check_for_linting_errors.yml
@@ -50,7 +50,7 @@ jobs:
         label: linting
         message: ${{ job.status == 'success' && '✓' || 'x' }}
         color: ${{ job.status == 'success' && 'green' || 'red' }}
-      if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push'
+      if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push' && github.repository == 'intrinsic-opensource/ros-central-registry'
 
   check_python_linting:
     name: Lint all Python files
@@ -77,4 +77,4 @@ jobs:
         label: python linting
         message: ${{ job.status == 'success' && '✓' || 'x' }}
         color: ${{ job.status == 'success' && 'green' || 'red' }}
-      if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push'
+      if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push' && github.repository == 'intrinsic-opensource/ros-central-registry'

--- a/.github/workflows/_check_tooling.yml
+++ b/.github/workflows/_check_tooling.yml
@@ -50,4 +50,4 @@ jobs:
         label: tooling
         message: ${{ job.status == 'success' && '✓' || 'x' }}
         color: ${{ job.status == 'success' && 'green' || 'red' }}
-      if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push'
+      if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push' && github.repository == 'intrinsic-opensource/ros-central-registry'

--- a/.github/workflows/_check_tooling.yml
+++ b/.github/workflows/_check_tooling.yml
@@ -50,4 +50,4 @@ jobs:
         label: tooling
         message: ${{ job.status == 'success' && '✓' || 'x' }}
         color: ${{ job.status == 'success' && 'green' || 'red' }}
-      if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push' && github.repository == 'intrinsic-opensource/ros-central-registry'
+      if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push' && (github.event.pull_request.head.repo.full_name || github.repository) == 'intrinsic-opensource/ros-central-registry'

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -51,7 +51,7 @@ jobs:
 
     steps:
     - name: Reset status badge
-      if: github.repository == 'intrinsic-opensource/ros-central-registry'
+      if: (github.event.pull_request.head.repo.full_name || github.repository) == 'intrinsic-opensource/ros-central-registry'
       uses: Schneegans/dynamic-badges-action@v1.8.0
       with:
         auth: ${{ secrets.STATUS_BADGE_SECRET }}
@@ -94,7 +94,7 @@ jobs:
         path: deploy
 
     - name: Notify the RCR-UI to rebuild
-      if: github.ref == 'refs/heads/main' && github.repository == 'intrinsic-opensource/ros-central-registry'
+      if: github.ref == 'refs/heads/main' && (github.event.pull_request.head.repo.full_name || github.repository) == 'intrinsic-opensource/ros-central-registry'
       uses: peter-evans/repository-dispatch@v4
       with:
         token: ${{ secrets.RCR_UI_PAT_TOKEN }}
@@ -110,7 +110,7 @@ jobs:
         label: deployment
         message: ${{ job.status == 'success' && '✓' || 'x' }}
         color: ${{ job.status == 'success' && 'green' || 'red' }}
-      if: always() && github.repository == 'intrinsic-opensource/ros-central-registry'
+      if: always() && (github.event.pull_request.head.repo.full_name || github.repository) == 'intrinsic-opensource/ros-central-registry'
 
   deploy:
     needs: generate

--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -51,6 +51,7 @@ jobs:
 
     steps:
     - name: Reset status badge
+      if: github.repository == 'intrinsic-opensource/ros-central-registry'
       uses: Schneegans/dynamic-badges-action@v1.8.0
       with:
         auth: ${{ secrets.STATUS_BADGE_SECRET }}
@@ -93,7 +94,7 @@ jobs:
         path: deploy
 
     - name: Notify the RCR-UI to rebuild
-      if: github.ref == 'refs/heads/main'
+      if: github.ref == 'refs/heads/main' && github.repository == 'intrinsic-opensource/ros-central-registry'
       uses: peter-evans/repository-dispatch@v4
       with:
         token: ${{ secrets.RCR_UI_PAT_TOKEN }}
@@ -109,7 +110,7 @@ jobs:
         label: deployment
         message: ${{ job.status == 'success' && '✓' || 'x' }}
         color: ${{ job.status == 'success' && 'green' || 'red' }}
-      if: always()
+      if: always() && github.repository == 'intrinsic-opensource/ros-central-registry'
 
   deploy:
     needs: generate

--- a/examples/.bazelrc
+++ b/examples/.bazelrc
@@ -67,14 +67,24 @@ common --remote_cache=https://storage.googleapis.com/intrinsic-opensource-buildc
 common --remote_cache_compression=true
 common --remote_upload_local_results=false
 
-# CI specific options for remote cache writing and performance tweaks.
-common:ci --remote_upload_local_results=true
-common:ci --google_default_credentials
+# CI specific options for performance/reliability tweaks -- safe to use
+# anywhere, requires no credentials (this is what forks get).
 common:ci --http_timeout_scaling=3.0
 common:ci --experimental_repository_downloader_retries=10
 common:ci --remote_cache_compression=false
 common:ci --nobuild_runfile_links
 common:ci --ui_event_filters=-INFO,-DEBUG
+
+# Remote cache writing -- only usable where GCP credentials for the
+# upstream repo's build cache are actually available. See
+# .github/workflows/_check_distribution_examples.yml's "Authenticate to
+# Google Cloud" step, which only adds --config=ci-cache-write when it ran
+# (unlike workspace/.bazelrc, generated per-run by
+# //tools/ci:setup_workspace, this file is static, so the same
+# credentials gate has to be a separate config here rather than a
+# generator flag).
+common:ci-cache-write --remote_upload_local_results=true
+common:ci-cache-write --google_default_credentials
 
 # Automatically pick configurations for the platform running bazel.
 # For example, macos on macos, linux on linux, etc.

--- a/tools/ci/setup_workspace.py
+++ b/tools/ci/setup_workspace.py
@@ -110,14 +110,15 @@ common --remote_cache=https://storage.googleapis.com/intrinsic-opensource-buildc
 common --remote_cache_compression=true
 common --remote_upload_local_results=false
 
-# CI specific options for remote cache writing and performance tweaks.
-common:ci --remote_upload_local_results=true
-common:ci --google_default_credentials
+# CI specific performance/reliability tweaks -- safe to use anywhere,
+# require no credentials (this is what forks get; see cache_write_config
+# below for the part that isn't safe on a fork).
 common:ci --http_timeout_scaling=3.0
 common:ci --experimental_repository_downloader_retries=10
 common:ci --remote_cache_compression=false
 common:ci --nobuild_runfile_links
 common:ci --ui_event_filters=-INFO,-DEBUG
+{cache_write_config}
 
 # We support the following variants of ROS distributions. This allows you
 # to build or test the entire variant with a --config flag.
@@ -219,6 +220,22 @@ test:ci --test_strategy=exclusive
 test:ci --strategy=TestRunner=standalone
 """
 
+
+def render_bazelrc(distro: str, variants: str, tmpdir: str, remote_cache_write: bool = False) -> str:
+    """
+    Fill in BAZELRC_TEMPLATE. remote_cache_write gates the two flags that
+    require GCP credentials (--remote_upload_local_results=true and
+    --google_default_credentials) -- see --remote-cache-write's help text.
+    """
+    cache_write_config = (
+        "common:ci --remote_upload_local_results=true\n"
+        "common:ci --google_default_credentials"
+    ) if remote_cache_write else ""
+    return BAZELRC_TEMPLATE.format(
+        distro=distro, variants=variants, tmpdir=tmpdir, cache_write_config=cache_write_config
+    )
+
+
 def get_copyright_header() -> str:
     return """# Copyright 2026 Open Source Robotics Foundation, Inc.
 #
@@ -285,6 +302,19 @@ def main():
         default="",
         help="Directory to pin TMPDIR to for build/test/run actions, e.g. "
              "$RUNNER_TEMP. Falls back to $TMPDIR, then /tmp, if not given.",
+    )
+    parser.add_argument(
+        "--remote-cache-write",
+        action="store_true",
+        help="Enable writing to the shared remote build cache under "
+             "--config ci (requires GCP credentials for the "
+             "intrinsic-opensource-buildcache bucket, e.g. via "
+             "google-github-actions/auth in the upstream repo's own CI). "
+             "Leave this off anywhere else -- forks don't have those "
+             "credentials, and attempting to write without them fails the "
+             "build rather than just skipping the write. The default "
+             "(non-ci) config already gives every caller anonymous "
+             "read-only access to the cache, so this only affects writes.",
     )
     args = parser.parse_args()
 
@@ -475,7 +505,7 @@ register_toolchains(
         for variant_name in VARIANTS
     )
     with open(target_workspace / ".bazelrc", "w") as f:
-        f.write(BAZELRC_TEMPLATE.format(distro=distro, variants=variants, tmpdir=tmpdir))
+        f.write(render_bazelrc(distro, variants, tmpdir, args.remote_cache_write))
 
     print("Workspace setup complete.")
 

--- a/tools/ci/setup_workspace_test.py
+++ b/tools/ci/setup_workspace_test.py
@@ -20,6 +20,21 @@ from pathlib import Path
 from tools.ci import setup_workspace
 
 
+class TestRenderBazelrc(unittest.TestCase):
+
+    def test_cache_write_off_by_default(self):
+        content = setup_workspace.render_bazelrc("lyrical", "", "/tmp")
+        self.assertNotIn("--remote_upload_local_results=true", content)
+        self.assertNotIn("--google_default_credentials", content)
+        # The safe, credential-free performance flags are always present.
+        self.assertIn("common:ci --http_timeout_scaling=3.0", content)
+
+    def test_cache_write_enabled_opt_in(self):
+        content = setup_workspace.render_bazelrc("lyrical", "", "/tmp", remote_cache_write=True)
+        self.assertIn("common:ci --remote_upload_local_results=true", content)
+        self.assertIn("common:ci --google_default_credentials", content)
+
+
 class TestCalculatePackagesForVariant(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
## Summary

Two related fork-safety fixes, both stemming from CI steps that assume they're running in the canonical upstream repo (`intrinsic-opensource/ros-central-registry`) when they might be running in a fork:

**1. Remote cache writes.** `--config ci` bundled safe performance/reliability flags together with cache-**write**-enabling (`--remote_upload_local_results=true` + `--google_default_credentials`), which needs GCP credentials only the upstream repo's Workload Identity Federation trust policy grants. On a fork, `bazel` fails partway through the build trying to write to a cache it can't write to. Fix: made the write-enabling half strictly opt-in --
- `tools/ci/setup_workspace.py` gains a `--remote-cache-write` flag (off by default) gating those two lines in the generated `workspace/.bazelrc` (extracted into a testable `render_bazelrc()` helper).
- `examples/`'s separate, static `.bazelrc` gets the same gate via a distinct `common:ci-cache-write` config.
- `_check_distribution_compiles.yml`/`_check_distribution_tests.yml`/`_check_distribution_examples.yml` skip "Authenticate to Google Cloud" and only pass the write-enabling flag when `github.repository == 'intrinsic-opensource/ros-central-registry'`.

**2. Status badges and the RCR-UI rebuild notification.** These use secrets (`STATUS_BADGE_SECRET`, `RCR_UI_PAT_TOKEN`) and external targets (a shared gist, the `intrinsic-opensource/rcr-ui` repo) that only make sense upstream, but none of the existing conditions actually excluded a fork:
- All 7 reusable `_check_*.yml` workflows' badge-update steps were gated on `github.ref == 'refs/heads/main' && github.event_name == 'push'`, true on a fork's own `main` too -- added the same repo check to each.
- `commit.yaml` was worse: "Reset status badge" had **no condition at all**, "Notify the RCR-UI to rebuild" only checked the ref (not the repo) before dispatching an event against `intrinsic-opensource/rcr-ui` with a token a fork doesn't have, and "Update status badges" was gated on bare `always()`. All three now also require the upstream repo.

Verified: full `tools/ci` pytest suite passes (146 tests, 2 new), `ruff` clean, all 8 modified workflow YAML files parse and are `actionlint`-clean (aside from this repo's pre-existing `ubuntu-26.04` custom-runner-label warning, present on every workflow using that runner, unrelated to this change).

## Acknowledgements

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Code of Conduct](../CODE_OF_CONDUCT.md) and agree to abide by it.
- [x] I have read and complied with the [OSRF Policy on the Use of Generative AI Tools ("Generative AI") in Contributions](https://github.com/openrobotics/osra-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md).

## Generative AI disclosure

- Was any generative AI tool used in this contribution? Yes.
- If yes, which tool(s), and for which part(s) of the contribution? Claude (Sonnet 5) authored this entire contribution interactively, including finding the RCR-UI notification issue while investigating the badge-update pattern.

## Related issue(s)

- Fixes: N/A -- prompted by CI failures observed on this fork's own runs.

## Additional information

Behavior on the upstream repo is unchanged in every case -- these fixes only change what happens on forks/other repos.
