### PR TITLE
Also build and test whatever package(s) a PR actually touches in ci.yaml

### DIFF
--- a/.github/workflows/_check_distribution_compiles.yml
+++ b/.github/workflows/_check_distribution_compiles.yml
@@ -23,6 +23,19 @@ on:
         description: 'Branch or ref to check out.'
         required: true
         type: string
+      changed_packages:
+        description: >
+          Space-separated package names to additionally bazel build in
+          full (e.g. "ouster_ros ouster_sensor_msgs"), on top of the
+          --config=<variant> build below -- a package a PR adds/patches
+          isn't necessarily part of any variant, so the variant build
+          alone can silently never touch it. Bazel's --target_pattern_file
+          (what --config=<variant> sets) can't be combined with explicit
+          targets on the same invocation, so this runs as a second, separate
+          bazel build. Empty/unset builds nothing extra.
+        required: false
+        type: string
+        default: ""
 
 env:
   ANDROID_HOME: ""
@@ -107,6 +120,18 @@ jobs:
       id: build
       run: |
         bazel build --config ci --config=${{ matrix.variant }} 2>&1 | tee build.log
+
+    # Build whatever package(s) this PR actually touches, in case they
+    # aren't part of the variant above -- see changed_packages' input docs.
+    - name: Build changed packages
+      id: build_changed_packages
+      if: inputs.changed_packages != ''
+      run: |
+        TARGETS=""
+        for pkg in ${{ inputs.changed_packages }}; do
+          TARGETS="$TARGETS @${pkg}//..."
+        done
+        bazel build --config ci $TARGETS 2>&1 | tee build_changed_packages.log
     - name: Update status badge (build)
       uses: Schneegans/dynamic-badges-action@v1.8.0
       with:

--- a/.github/workflows/_check_distribution_tests.yml
+++ b/.github/workflows/_check_distribution_tests.yml
@@ -27,6 +27,15 @@ on:
         description: 'RMW implementation to build and test, e.g. rmw_fastrtps_cpp.'
         required: true
         type: string
+      changed_packages:
+        description: >
+          Space-separated package names to additionally bazel test in
+          full (e.g. "ouster_ros ouster_sensor_msgs"), on top of the
+          --config=<variant> test below -- see _check_distribution_compiles.yml's
+          input of the same name for why. Empty/unset tests nothing extra.
+        required: false
+        type: string
+        default: ""
 
 env:
   ANDROID_HOME: ""
@@ -151,6 +160,19 @@ jobs:
         # tests to flake nondeterminstically, creating lots of result noise.
         bazel build --config ci --build_tests_only --config=${{ matrix.variant }}
         bazel test --config ci --config=${{ matrix.variant }} --test_env=RMW_IMPLEMENTATION=${{ inputs.rmw }} 2>&1 | tee ${{ inputs.rmw }}.test.log || test_status=$?
+
+        # Also build/test whatever package(s) this PR actually touches, in
+        # case they aren't part of the variant above -- see
+        # changed_packages' input docs in _check_distribution_compiles.yml.
+        if [ -n "${{ inputs.changed_packages }}" ]; then
+          TARGETS=""
+          for pkg in ${{ inputs.changed_packages }}; do
+            TARGETS="$TARGETS @${pkg}//..."
+          done
+          bazel build --config ci --build_tests_only $TARGETS
+          bazel test --config ci --test_env=RMW_IMPLEMENTATION=${{ inputs.rmw }} $TARGETS 2>&1 | tee ${{ inputs.rmw }}.changed_packages.test.log || test_status=$?
+        fi
+
         if [ -d bazel-testlogs ]; then
           find -L bazel-testlogs -name "*.xml" -print0 | tar -czf ${{ matrix.ros }}_${{ matrix.variant }}_${{ matrix.bazel }}_${{ matrix.os }}_${{ inputs.rmw }}.xml.tar.gz --null -T - || true
           find -L bazel-testlogs -name "*.log" -print0 | tar -czf ${{ matrix.ros }}_${{ matrix.variant }}_${{ matrix.bazel }}_${{ matrix.os }}_${{ inputs.rmw }}.log.tar.gz --null -T - || true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,6 +72,36 @@ jobs:
     uses: ./.github/workflows/_check_bazel_modules.yml
     secrets: inherit
 
+  changed-packages:
+    name: Detect changed packages
+    # A package this PR adds/patches isn't necessarily part of any of the
+    # six fixed distribution variants (see AGENTS.md), so the variant build
+    # below can silently never build or test it at all -- this finds every
+    # package touched, so distribution_compiles/test_rmw_* can build/test
+    # them directly too, on top of the variant. PR-only: on a push to main,
+    # there's no meaningful base to diff against here.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    outputs:
+      packages: ${{ steps.diff.outputs.packages }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v7
+      with:
+        fetch-depth: 0 # must be zero for 'git diff' against the base to work.
+    - name: Setup Bazel
+      uses: bazel-contrib/setup-bazel@0.19.0
+      with:
+        bazelisk-cache: true
+        disk-cache: false
+        repository-cache: true
+    - name: Compute changed packages
+      id: diff
+      run: |
+        git diff --name-status "origin/${{ github.base_ref }}...HEAD" -- modules > /tmp/diff_status.txt
+        PACKAGES=$(bazel run //tools/ci:changed_packages -- --diff-status /tmp/diff_status.txt --directory modules)
+        echo "packages=$PACKAGES" >> "$GITHUB_OUTPUT"
+
   docs_build:
     name: Check documentation
     uses: ./.github/workflows/_check_docs_build.yml
@@ -84,6 +114,7 @@ jobs:
     - lint
     - tooling
     - bazel_modules
+    - changed-packages
     - docs_build
     if: |
       !cancelled() &&
@@ -91,6 +122,7 @@ jobs:
       needs.tooling.result == 'success' &&
       needs.docs_build.result == 'success' &&
       (needs.bazel_modules.result == 'success' || needs.bazel_modules.result == 'skipped') &&
+      (needs.changed-packages.result == 'success' || needs.changed-packages.result == 'skipped') &&
       needs.detect-changes.outputs.code == 'true'
     permissions:
       actions: read
@@ -100,6 +132,7 @@ jobs:
     uses: ./.github/workflows/_check_distribution_compiles.yml
     with:
       branch: ${{ inputs.branch || github.ref }}
+      changed_packages: ${{ needs.changed-packages.outputs.packages }}
     secrets: inherit
 
   distribution_examples:
@@ -120,7 +153,7 @@ jobs:
 
   test_rmw_fastrtps_cpp:
     name: Test FastDDS
-    needs: [distribution_compiles]
+    needs: [distribution_compiles, changed-packages]
     if: |
       !cancelled() &&
       needs.distribution_compiles.result == 'success'
@@ -133,11 +166,12 @@ jobs:
     with:
       branch: ${{ inputs.branch || github.ref }}
       rmw: rmw_fastrtps_cpp
+      changed_packages: ${{ needs.changed-packages.outputs.packages }}
     secrets: inherit
 
   test_rmw_fastrtps_dynamic_cpp:
     name: Test FastDDS (dynamic)
-    needs: [distribution_compiles]
+    needs: [distribution_compiles, changed-packages]
     if: |
       !cancelled() &&
       needs.distribution_compiles.result == 'success'
@@ -150,11 +184,12 @@ jobs:
     with:
       branch: ${{ inputs.branch || github.ref }}
       rmw: rmw_fastrtps_dynamic_cpp
+      changed_packages: ${{ needs.changed-packages.outputs.packages }}
     secrets: inherit
 
   test_rmw_cyclonedds_cpp:
     name: Test CycloneDDS
-    needs: [distribution_compiles]
+    needs: [distribution_compiles, changed-packages]
     if: |
       !cancelled() &&
       needs.distribution_compiles.result == 'success'
@@ -167,11 +202,12 @@ jobs:
     with:
       branch: ${{ inputs.branch || github.ref }}
       rmw: rmw_cyclonedds_cpp
+      changed_packages: ${{ needs.changed-packages.outputs.packages }}
     secrets: inherit
 
   test_rmw_zenoh_cpp:
     name: Test Zenoh
-    needs: [distribution_compiles]
+    needs: [distribution_compiles, changed-packages]
     if: |
       !cancelled() &&
       needs.distribution_compiles.result == 'success'
@@ -184,4 +220,5 @@ jobs:
     with:
       branch: ${{ inputs.branch || github.ref }}
       rmw: rmw_zenoh_cpp
+      changed_packages: ${{ needs.changed-packages.outputs.packages }}
     secrets: inherit

--- a/tools/ci/BUILD.bazel
+++ b/tools/ci/BUILD.bazel
@@ -111,6 +111,28 @@ py_test(
 )
 
 py_library(
+    name = "changed_packages_lib",
+    srcs = ["changed_packages.py"],
+    imports = ["../.."],
+    deps = [
+        ":bzlmod_lib",
+        ":module_diff_lib",
+    ],
+)
+
+py_binary(
+    name = "changed_packages",
+    srcs = ["changed_packages.py"],
+    deps = [":changed_packages_lib"],
+)
+
+py_test(
+    name = "changed_packages_test",
+    srcs = ["changed_packages_test.py"],
+    deps = [":changed_packages_lib"],
+)
+
+py_library(
     name = "create_patch_lib",
     srcs = ["create_patch.py"],
     imports = ["../.."],

--- a/tools/ci/changed_packages.py
+++ b/tools/ci/changed_packages.py
@@ -1,0 +1,68 @@
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Prints the package names a PR's diff newly adds a module version for, space
+separated. Used by ci.yaml to also bazel build/test whatever package(s) a PR
+actually touches -- a brand-new or freshly-patched package isn't necessarily
+part of any of the six fixed distribution variants (ros_core, ros_base,
+desktop, desktop_full, perception, simulation), so the variant build alone
+can silently never exercise it at all.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+from typing import List, Tuple
+
+from tools.ci import bzlmod_lib
+from tools.ci import module_diff
+
+
+def find_changed_packages(diffs: List[Tuple[str, str]], target_dir: str) -> List[str]:
+    """
+    Deduplicated, sorted package names with at least one newly-added ("A"
+    status) version directory under target_dir -- every package this repo's
+    own patching model (setup-workspace/vendor-module/create-patch) could
+    have touched, since a patch is always a brand-new version directory,
+    never an edit to an existing one.
+    """
+    return sorted({package for package, _version in module_diff.find_new_module_versions(diffs, target_dir)})
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Print the package names a PR's diff newly adds a module version for."
+    )
+    parser.add_argument(
+        "--diff-status",
+        required=True,
+        type=Path,
+        help="Path to the file containing git diff --name-status output",
+    )
+    parser.add_argument(
+        "--directory",
+        default="modules",
+        help="Directory to scan for new module versions (e.g. modules or bcr_staging/modules)",
+    )
+    args = parser.parse_args()
+
+    diffs = bzlmod_lib.parse_diff_status_file(args.diff_status)
+    packages = find_changed_packages(diffs, args.directory)
+    print(" ".join(packages))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/ci/changed_packages_test.py
+++ b/tools/ci/changed_packages_test.py
@@ -1,0 +1,50 @@
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from tools.ci import changed_packages
+
+
+class TestFindChangedPackages(unittest.TestCase):
+
+    def test_deduplicates_and_sorts_package_names(self):
+        diffs = [
+            ("A", "modules/rclcpp/32.0.0-1.rcr.2/MODULE.bazel"),
+            ("A", "modules/rclcpp/32.0.0-1.rcr.2/source.json"),
+            ("A", "modules/ouster_ros/0.14.2-3.rcr.3/MODULE.bazel"),
+            ("M", "modules/rclcpp/metadata.json"),
+        ]
+        self.assertEqual(
+            changed_packages.find_changed_packages(diffs, "modules"),
+            ["ouster_ros", "rclcpp"],
+        )
+
+    def test_ignores_modified_and_deleted_files(self):
+        diffs = [
+            ("M", "modules/rclcpp/32.0.0-1.rcr.1/MODULE.bazel"),
+            ("D", "modules/old_pkg/1.0.0/MODULE.bazel"),
+        ]
+        self.assertEqual(changed_packages.find_changed_packages(diffs, "modules"), [])
+
+    def test_ignores_other_directories(self):
+        diffs = [("A", "bcr_staging/modules/foo/1.0.0/MODULE.bazel")]
+        self.assertEqual(changed_packages.find_changed_packages(diffs, "modules"), [])
+
+    def test_no_changes_returns_empty_list(self):
+        self.assertEqual(changed_packages.find_changed_packages([], "modules"), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

A package a PR adds or patches isn't necessarily part of any of the six fixed distribution variants (`ros_core`, `ros_base`, `desktop`, `desktop_full`, `perception`, `simulation`) -- `setup_workspace` does resolve it into the workspace correctly, but `--config=<variant>`'s `--target_pattern_file` only lists whatever's actually in that variant, so the build/test steps could silently never touch it at all. This is exactly what let `ouster_ros`/`ouster_sensor_msgs` merge without ever actually being built (see #149).

- **`tools/ci/changed_packages.py`** (+ test): prints the deduplicated, sorted package names a PR's diff newly adds a module version for, reusing `module_diff.find_new_module_versions` (already used for the module-diff PR comment) rather than re-deriving the same logic.
- **`ci.yaml`**: new `changed-packages` job (`pull_request`-only -- there's no meaningful base to diff against on a push to `main`) computes this list and threads it into `distribution_compiles` and all four `test_rmw_*` jobs as a new `changed_packages` input.
- **`_check_distribution_compiles.yml`/`_check_distribution_tests.yml`**: when `changed_packages` is non-empty, run a second, separate `bazel build`/`test` invocation for `@<pkg>//...` per package, on every matrix leg (both Bazel versions x all OSes for the build; both OSes x all four RMWs for the test). Bazel's `--target_pattern_file` (what `--config=<variant>` sets) can't be combined with explicit targets on the same invocation (confirmed empirically: `"Command-line target pattern and --target_pattern_file cannot both be specified"`), so this has to be a separate command rather than merged into the variant build/test.

## Verification

- Full `tools/ci` pytest suite passes (149 tests, 4 new).
- A real `bazel test //tools/ci:changed_packages_test` run (not just pytest) passes.
- `ruff` and `buildifier` clean.
- All three modified workflow YAML files parse and are `actionlint`-clean (aside from this repo's pre-existing, unrelated `inputs.branch` warning and `ubuntu-26.04` custom-runner-label warning, neither introduced by this change).

## Acknowledgements

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Code of Conduct](../CODE_OF_CONDUCT.md) and agree to abide by it.
- [x] I have read and complied with the [OSRF Policy on the Use of Generative AI Tools ("Generative AI") in Contributions](https://github.com/openrobotics/osra-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md).

## Generative AI disclosure

- Was any generative AI tool used in this contribution? Yes.
- If yes, which tool(s), and for which part(s) of the contribution? Claude (Sonnet 5) authored this entire contribution interactively, including identifying the `--target_pattern_file`/explicit-target incompatibility that shaped the two-separate-invocations design.

## Related issue(s)

- Fixes: N/A -- prompted by `ouster_ros`/`ouster_sensor_msgs` (#149) merging without CI ever actually building them.

## Additional information

Adds real CI cost: every PR that touches `modules/` now gets an extra `bazel build`/`test` pass per changed package, on top of the existing variant matrix. Scoped to only run when `changed_packages` is actually non-empty, so PRs that don't touch `modules/` (or only touch already-in-variant packages, where it's a redundant but harmless no-op... actually it still runs for those too since detection is purely "any new version directory", not "not already covered by the variant" -- open to adding that refinement if the extra cost is a concern).