### PR TITLE
fix: post module-diff PR comments for fork PRs via workflow_run

### DIFF
--- a/.github/workflows/_check_bazel_modules.yml
+++ b/.github/workflows/_check_bazel_modules.yml
@@ -89,6 +89,17 @@ jobs:
             --diff-status /tmp/diff_status.txt \
             --directory "${{ matrix.directory }}" \
             --output /tmp/module_diff.md
+    - name: Write module diff to job summary
+      # Always runs, including for fork PRs: unlike the PR comment below,
+      # writing to GITHUB_STEP_SUMMARY needs no token permissions at all,
+      # so this is the one place a fork PR's module diff is guaranteed to
+      # be visible for review.
+      if: always()
+      run: |
+        if [ -s /tmp/module_diff.md ]; then
+          echo "### Module diff (${{ matrix.directory }})" >> "$GITHUB_STEP_SUMMARY"
+          cat /tmp/module_diff.md >> "$GITHUB_STEP_SUMMARY"
+        fi
     - name: Post module diff to PR
       # Only meaningful on a real pull_request event -- weekly_rollup.yml
       # calls this workflow before any PR exists (see the comment at the
@@ -96,7 +107,8 @@ jobs:
       # skipped for fork PRs: GitHub forces GITHUB_TOKEN to read-only for
       # pull_request events triggered from a fork, regardless of the
       # `permissions:` block above, so the comment API call would just
-      # fail with "Resource not accessible by integration".
+      # fail with "Resource not accessible by integration". The job
+      # summary step above still surfaces the diff in that case.
       if: |
         always() && github.event_name == 'pull_request' &&
         (github.event.pull_request.head.repo.full_name || github.repository) == 'intrinsic-opensource/ros-central-registry'

--- a/.github/workflows/_check_bazel_modules.yml
+++ b/.github/workflows/_check_bazel_modules.yml
@@ -92,8 +92,14 @@ jobs:
     - name: Post module diff to PR
       # Only meaningful on a real pull_request event -- weekly_rollup.yml
       # calls this workflow before any PR exists (see the comment at the
-      # top of this file), so there's nothing to comment on there.
-      if: always() && github.event_name == 'pull_request'
+      # top of this file), so there's nothing to comment on there. Also
+      # skipped for fork PRs: GitHub forces GITHUB_TOKEN to read-only for
+      # pull_request events triggered from a fork, regardless of the
+      # `permissions:` block above, so the comment API call would just
+      # fail with "Resource not accessible by integration".
+      if: |
+        always() && github.event_name == 'pull_request' &&
+        (github.event.pull_request.head.repo.full_name || github.repository) == 'intrinsic-opensource/ros-central-registry'
       uses: actions/github-script@v9
       with:
         script: |

--- a/.github/workflows/_check_bazel_modules.yml
+++ b/.github/workflows/_check_bazel_modules.yml
@@ -40,7 +40,6 @@ env:
 
 permissions:
   contents: read
-  pull-requests: write # to post/update the module-diff comment below.
 
 jobs:
   check_bazel_modules:
@@ -100,56 +99,27 @@ jobs:
           echo "### Module diff (${{ matrix.directory }})" >> "$GITHUB_STEP_SUMMARY"
           cat /tmp/module_diff.md >> "$GITHUB_STEP_SUMMARY"
         fi
-    - name: Post module diff to PR
-      # Only meaningful on a real pull_request event -- weekly_rollup.yml
-      # calls this workflow before any PR exists (see the comment at the
-      # top of this file), so there's nothing to comment on there. Also
-      # skipped for fork PRs: GitHub forces GITHUB_TOKEN to read-only for
-      # pull_request events triggered from a fork, regardless of the
-      # `permissions:` block above, so the comment API call would just
-      # fail with "Resource not accessible by integration". The job
-      # summary step above still surfaces the diff in that case.
-      if: |
-        always() && github.event_name == 'pull_request' &&
-        (github.event.pull_request.head.repo.full_name || github.repository) == 'intrinsic-opensource/ros-central-registry'
-      uses: actions/github-script@v9
+    - name: Compute artifact name
+      # Artifact names can't contain '/', so sanitize the matrix directory
+      # (e.g. "bcr_staging/modules" -> "bcr_staging-modules"). The
+      # post_module_diff_comment.yml workflow reverses this to recover the
+      # original directory for the comment marker.
+      if: always()
+      id: artifact_name
+      run: echo "name=$(echo '${{ matrix.directory }}' | tr '/' '-')" >> "$GITHUB_OUTPUT"
+    - name: Upload module diff artifact
+      # Uploading artifacts needs no special token permissions and works
+      # the same on fork PRs, unlike posting a PR comment directly (see
+      # the job summary step above). A separate, privileged workflow_run
+      # listener (post_module_diff_comment.yml) downloads this artifact
+      # from the base repo's context and posts/updates the PR comment.
+      if: always()
+      uses: actions/upload-artifact@v7
       with:
-        script: |
-          const fs = require('fs');
-          const path = '/tmp/module_diff.md';
-          if (!fs.existsSync(path)) return;
-          const diff = fs.readFileSync(path, 'utf8').trim();
-          if (!diff) return;
-
-          // Marker scopes the comment to this matrix directory, so
-          // "modules" and "bcr_staging/modules" each get their own
-          // comment, and re-runs update the same comment instead of
-          // piling up duplicates.
-          const marker = `<!-- module-diff: ${{ matrix.directory }} -->`;
-          const body = `${marker}\n${diff}`;
-
-          const { data: comments } = await github.rest.issues.listComments({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            issue_number: context.issue.number,
-          });
-          const existing = comments.find((c) => c.body.includes(marker));
-
-          if (existing) {
-            await github.rest.issues.updateComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: existing.id,
-              body,
-            });
-          } else {
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body,
-            });
-          }
+        name: module-diff-${{ steps.artifact_name.outputs.name }}
+        path: /tmp/module_diff.md
+        if-no-files-found: ignore
+        retention-days: 7
     - name: Update status badges
       uses: Schneegans/dynamic-badges-action@v1.8.0
       with:

--- a/.github/workflows/post_module_diff_comment.yml
+++ b/.github/workflows/post_module_diff_comment.yml
@@ -1,0 +1,119 @@
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Posts/updates the module-diff PR comment produced by
+# _check_bazel_modules.yml (part of the `ci` workflow). This is a
+# separate, workflow_run-triggered workflow rather than a step inside
+# `ci` itself because `ci` can run against a fork PR, where GitHub forces
+# GITHUB_TOKEN to read-only and a direct comment attempt from within that
+# run fails with "Resource not accessible by integration".
+#
+# workflow_run always executes the workflow file as committed on this
+# repo's default branch -- never the fork PR's own version -- so granting
+# it write permissions here does not give a fork PR branch any control
+# over what runs. This is the standard safe pattern for commenting on
+# fork PRs (as opposed to `pull_request_target`, which would run the
+# fork's own workflow file, and possibly its code, with write access).
+
+name: post_module_diff_comment
+
+on:
+  workflow_run:
+    workflows: ["ci"]
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read # to download artifacts from the triggering run.
+  pull-requests: write # to post/update the module-diff comment.
+
+jobs:
+  comment:
+    name: Post module diff comment
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download module diff artifacts
+      uses: actions/download-artifact@v7
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        run-id: ${{ github.event.workflow_run.id }}
+        pattern: module-diff-*
+        path: /tmp/module-diffs
+      # No artifacts exist if _check_bazel_modules.yml never ran (e.g. a
+      # push-triggered run, filtered out by the `if:` above) or failed
+      # before the upload step.
+      continue-on-error: true
+
+    - name: Post module diff comments
+      uses: actions/github-script@v9
+      with:
+        script: |
+          const fs = require('fs');
+          const path = require('path');
+
+          const root = '/tmp/module-diffs';
+          if (!fs.existsSync(root)) return;
+
+          // workflow_run's own `pull_requests` field is empty for
+          // fork-originated PRs, so resolve the PR from the run's head
+          // commit instead, which works regardless of fork status.
+          const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            commit_sha: context.payload.workflow_run.head_sha,
+          });
+          const pr = prs.find((p) => p.state === 'open');
+          if (!pr) return;
+
+          const { data: comments } = await github.rest.issues.listComments({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: pr.number,
+          });
+
+          for (const artifactDir of fs.readdirSync(root)) {
+            // Reverses the sanitization in _check_bazel_modules.yml's
+            // "Compute artifact name" step, e.g.
+            // "module-diff-bcr_staging-modules" -> "bcr_staging/modules".
+            const directory = artifactDir.replace(/^module-diff-/, '').replace(/-/g, '/');
+            const diffPath = path.join(root, artifactDir, 'module_diff.md');
+            if (!fs.existsSync(diffPath)) continue;
+            const diff = fs.readFileSync(diffPath, 'utf8').trim();
+            if (!diff) continue;
+
+            // Marker scopes the comment to this matrix directory, so
+            // "modules" and "bcr_staging/modules" each get their own
+            // comment, and re-runs update the same comment instead of
+            // piling up duplicates.
+            const marker = `<!-- module-diff: ${directory} -->`;
+            const body = `${marker}\n${diff}`;
+            const existing = comments.find((c) => c.body.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body,
+              });
+            }
+          }


### PR DESCRIPTION
## Summary

- `_check_bazel_modules.yml`'s "Post module diff to PR" step was failing on fork-originated PRs (e.g. #149) with `HttpError: Resource not accessible by integration`. GitHub forces `GITHUB_TOKEN` to read-only for `pull_request` events triggered from a fork, regardless of the `pull-requests: write` permission declared in the workflow, so the `createComment`/`updateComment` calls 403.
- `_check_bazel_modules.yml` now uploads the diff as a build artifact (needs no special token permissions, works the same on forks) and also writes it to the job's `GITHUB_STEP_SUMMARY` as an immediate fallback.
- A new privileged `post_module_diff_comment.yml`, triggered on `workflow_run` for `ci`, downloads that artifact and posts/updates the PR comment. `workflow_run` always executes the workflow file from this repo's default branch -- never the fork PR's own version -- so it gets real write permissions without ever running untrusted fork code. This is the standard safe alternative to `pull_request_target` for commenting on fork PRs.
- Since `workflow_run.pull_requests` is empty for fork-originated PRs, the PR is instead resolved from the run's head commit via `listPullRequestsAssociatedWithCommit`.
- Net effect: every PR (fork or same-repo) gets the module-diff comment back, the way it worked before this fix, just routed through a safe indirection for forks.

## Acknowledgements

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Code of Conduct](../CODE_OF_CONDUCT.md) and agree to abide by it.
- [x] I have read and complied with the [OSRF Policy on the Use of Generative AI Tools ("Generative AI") in Contributions](https://github.com/openrobotics/osra-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md).

## Generative AI disclosure

- Was any generative AI tool used in this contribution? Yes
- If yes, which tool(s), and for which part(s) of the contribution? Claude Code (Anthropic) was used to diagnose the CI failure and author the workflow changes and this PR description, under my direction and review.

## Related issue(s)

- Fixes: none tracked; found and fixed while reviewing CI failures on #149.

## Additional information

- Test plan:
  - [x] `python3 -c "import yaml; yaml.safe_load(...)"` on both changed/new files
  - [x] `actionlint` clean (aside from the pre-existing unrelated `ubuntu-26.04` runner-label false positive)
  - [ ] Confirm the "Check modules" job no longer fails on a fork PR run
  - [ ] Confirm `post_module_diff_comment.yml` posts the comment for both a fork PR and a same-repo PR