### PR TITLE
fix: add ogre@1.12.10.rcr.0, fixing GLX/GL headers and libc++ compat

### DIFF
--- a/bcr_staging/modules/ogre/1.12.10.rcr.0/MODULE.bazel
+++ b/bcr_staging/modules/ogre/1.12.10.rcr.0/MODULE.bazel
@@ -1,0 +1,34 @@
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module(
+    name = "ogre",
+    version = "1.12.10.rcr.0",
+    bazel_compatibility = [">=7.2.1"],
+)
+
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "egl-registry", version = "0.0.0-20250527")
+bazel_dep(name = "freetype", version = "2.14.1")
+bazel_dep(name = "glew", version = "2.3.1")
+bazel_dep(name = "imgui", version = "1.79")
+bazel_dep(name = "libx11", version = "1.8.12.bcr.5")
+bazel_dep(name = "libxcb", version = "1.17.0.bcr.2")
+bazel_dep(name = "libxrandr", version = "1.5.4")
+bazel_dep(name = "opengl-registry", version = "0.0.0-20250707")
+bazel_dep(name = "platforms", version = "1.1.0")
+bazel_dep(name = "rules_cc", version = "0.2.22")
+bazel_dep(name = "rules_license", version = "1.0.0")
+bazel_dep(name = "zlib", version = "1.3.1")
+bazel_dep(name = "zziplib", version = "0.13.72")

--- a/bcr_staging/modules/ogre/1.12.10.rcr.0/overlay/BUILD.bazel
+++ b/bcr_staging/modules/ogre/1.12.10.rcr.0/overlay/BUILD.bazel
@@ -1,0 +1,755 @@
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@bazel_skylib//rules:expand_template.bzl", "expand_template")
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_shared_library")
+load("@rules_license//rules:license.bzl", "license")
+
+package(default_visibility = ["//visibility:public"])
+
+license(
+    name = "license",
+    package_name = "ogre",
+)
+
+licenses(["notice"])
+
+exports_files(["LICENSE"])
+
+expand_template(
+    name = "OgreBuildSettings_h",
+    out = "OgreMain/include/OgreBuildSettings.h",
+    substitutions = {
+        "@OGRE_VERSION_MAJOR@": "1",
+        "@OGRE_VERSION_MINOR@": "12",
+        "@OGRE_VERSION_PATCH@": "10",
+        "@OGRE_VERSION_SUFFIX@": "rviz",
+        "@OGRE_VERSION_NAME@": "Ogre 1.12",
+        "@OGRE_SET_ASSERT_MODE@": "1",
+        "#cmakedefine OGRE_STATIC_LIB": "/* undef OGRE_STATIC_LIB */",
+        "#cmakedefine01 OGRE_DEBUG_MODE": "#define OGRE_DEBUG_MODE 0",
+        "@OGRE_RESOURCEMANAGER_STRICT@": "2",
+        "#cmakedefine OGRE_NODELESS_POSITIONING": "/* undef OGRE_NODELESS_POSITIONING */",
+        "#cmakedefine OGRE_CONFIG_LITTLE_ENDIAN": "#define OGRE_CONFIG_LITTLE_ENDIAN 1",
+        "#cmakedefine OGRE_CONFIG_BIG_ENDIAN": "/* undef OGRE_CONFIG_BIG_ENDIAN */",
+        "#cmakedefine01 OGRE_DOUBLE_PRECISION": "#define  OGRE_DOUBLE_PRECISION 0",
+        "#cmakedefine01 OGRE_NODE_INHERIT_TRANSFORM": "#define OGRE_NODE_INHERIT_TRANSFORM 0",
+        "@OGRE_SET_THREADS@": "0",
+        "@OGRE_SET_THREAD_PROVIDER@": "0",
+        "#cmakedefine01 OGRE_NO_MESHLOD": "#define OGRE_NO_MESHLOD 0",
+        "#cmakedefine01 OGRE_NO_DDS_CODEC": "#define OGRE_NO_DDS_CODEC 0",
+        "#cmakedefine01 OGRE_NO_PVRTC_CODEC": "#define OGRE_NO_PVRTC_CODEC 1",
+        "#cmakedefine01 OGRE_NO_ETC_CODEC": "#define OGRE_NO_ETC_CODEC 0",
+        "#cmakedefine01 OGRE_NO_ASTC_CODEC": "#define OGRE_NO_ASTC_CODEC 1",
+        "#cmakedefine01 OGRE_NO_ZIP_ARCHIVE": "#define OGRE_NO_ZIP_ARCHIVE 1",
+        "#cmakedefine01 OGRE_NO_VIEWPORT_ORIENTATIONMODE": "#define OGRE_NO_VIEWPORT_ORIENTATIONMODE 1",
+        "#cmakedefine01 OGRE_NO_TBB_SCHEDULER": "#define OGRE_NO_TBB_SCHEDULER 0",
+        "#cmakedefine01 OGRE_PROFILING": "#define OGRE_PROFILING 0",
+        "#cmakedefine01 OGRE_NO_QUAD_BUFFER_STEREO": "#define OGRE_NO_QUAD_BUFFER_STEREO 0",
+        "#cmakedefine01 OGRE_NO_LOCALE_STRCONVERT": "#define OGRE_NO_LOCALE_STRCONVERT 0",
+    },
+    template = "CMake/Templates/OgreBuildSettings.h.in",
+)
+
+genrule(
+    name = "OgreExports_h",
+    outs = ["OgreMain/include/OgreExports.h"],
+    cmd = "echo '#ifndef _OgreExport_H' > $@ && " +
+          "echo '#define _OgreExport_H' >> $@ && " +
+          "echo '#define _OgreExport' >> $@ && " +
+          "echo '#define _OgrePrivate' >> $@ && " +
+          "echo '#define OGRE_DEPRECATED' >> $@ && " +
+          "echo '#endif' >> $@",
+)
+
+genrule(
+    name = "OgreComponents_h",
+    outs = ["OgreMain/include/OgreComponents.h"],
+    cmd = "echo '#ifndef __OGRE_COMPONENTS_Config_H_' > $@ && " +
+          "echo '#define __OGRE_COMPONENTS_Config_H_' >> $@ && " +
+          "echo '#define OGRE_BUILD_COMPONENT_PAGING' >> $@ && " +
+          "echo '#define OGRE_BUILD_COMPONENT_MESHLODGENERATOR' >> $@ && " +
+          "echo '#define OGRE_BUILD_COMPONENT_TERRAIN' >> $@ && " +
+          "echo '#define OGRE_BUILD_COMPONENT_VOLUME' >> $@ && " +
+          "echo '#define OGRE_BUILD_COMPONENT_PROPERTY' >> $@ && " +
+          "echo '#define OGRE_BUILD_COMPONENT_OVERLAY' >> $@ && " +
+          "echo '#define OGRE_BUILD_COMPONENT_OVERLAY_IMGUI' >> $@ && " +
+          "echo '#define OGRE_BUILD_COMPONENT_RTSHADERSYSTEM' >> $@ && " +
+          "echo '#endif' >> $@",
+)
+
+genrule(
+    name = "OgreRTShaderConfig_h",
+    outs = ["OgreMain/include/OgreRTShaderConfig.h"],
+    cmd = "echo '#ifndef COMPONENTS_RTSHADERSYSTEM_INCLUDE_OGRERTSHADERCONFIG_H_' > $@ && " +
+          "echo '#define COMPONENTS_RTSHADERSYSTEM_INCLUDE_OGRERTSHADERCONFIG_H_' >> $@ && " +
+          "echo '#define RTSHADER_SYSTEM_BUILD_CORE_SHADERS' >> $@ && " +
+          "echo '#define RTSHADER_SYSTEM_BUILD_EXT_SHADERS' >> $@ && " +
+          "echo '#endif' >> $@",
+)
+
+cc_library(
+    name = "OgreMain_library",
+    srcs = glob(
+        [
+            "OgreMain/src/*.cpp",
+            "OgreMain/src/*.h",
+        ],
+        allow_empty = True,
+    ) + [
+        "OgreMain/src/Threading/OgreDefaultWorkQueueStandard.cpp",
+    ] + select({
+        "@platforms//os:windows": glob(["OgreMain/src/WIN32/*.cpp"]),
+        "@platforms//os:osx": glob([
+            "OgreMain/src/OSX/*.cpp",
+            "OgreMain/src/OSX/*.h",
+        ]),
+        "//conditions:default": [],
+    }),
+    hdrs = glob(
+        [
+            "OgreMain/include/*.h",
+            "OgreMain/include/Threading/*.h",
+        ],
+        allow_empty = True,
+    ) + [
+        ":OgreBuildSettings_h",
+        ":OgreComponents_h",
+        ":OgreExports_h",
+        ":OgreRTShaderConfig_h",
+    ],
+    copts = select({
+        "@platforms//os:windows": [
+            "/std:c++17",
+        ],
+        "//conditions:default": [
+            "-std=c++17",
+            "-Wno-inconsistent-missing-override",
+            "-Wno-implicit-const-int-float-conversion",
+            "-Wno-deprecated-declarations",
+            # libc++ only keeps std::binary_function (still used by
+            # OgreLodStrategy.cpp) for _LIBCPP_STD_VER <= 14 -- -std=c++17
+            # alone isn't enough. This opts back into the deprecated,
+            # still-present fallback rather than patching ogre's source.
+            "-D_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION",
+        ],
+    }),
+    defines = [
+        "OGRE_BUILD_RENDERSYSTEM_D3D9=0",
+        "OGRE_BUILD_RENDERSYSTEM_D3D11=0",
+        "OGRE_BUILD_RENDERSYSTEM_GL3PLUS=1",
+        "OGRE_BUILD_RENDERSYSTEM_GL=1",
+        "OGRE_BUILD_RENDERSYSTEM_GLES2=0",
+        "OGRE_BUILD_RENDERSYSTEM_METAL=0",
+    ],
+    includes = [
+        "OgreMain/include",
+        "OgreMain/include/Threading",
+        "OgreMain/src",
+        "include",
+    ],
+)
+
+cc_shared_library(
+    name = "OgreMain",
+    exports_filter = [":OgreMain_library"],
+    deps = [":OgreMain_library"],
+)
+
+### Component: OgreMeshLodGenerator
+
+OGRE_MESH_LOADER_DEPS = {
+    ":OgreMain": "OgreMain_library",
+}
+
+cc_library(
+    name = "OgreMeshLodGenerator_library",
+    srcs = glob([
+        "Components/MeshLodGenerator/src/*.cpp",
+        "Components/MeshLodGenerator/src/*.h",
+    ]),
+    hdrs = glob(["Components/MeshLodGenerator/include/*.h"]),
+    includes = [
+        "Components/MeshLodGenerator/include",
+        "Components/MeshLodGenerator/src",
+    ],
+    deps = OGRE_MESH_LOADER_DEPS.values(),
+)
+
+cc_shared_library(
+    name = "OgreMeshLodGenerator",
+    dynamic_deps = OGRE_MESH_LOADER_DEPS.keys(),
+    exports_filter = [":OgreMeshLodGenerator_library"],
+    deps = [":OgreMeshLodGenerator_library"],
+)
+
+### Component: OgrePaging
+
+OGRE_PAGING_DEPS = {
+    ":OgreMain": "OgreMain_library",
+}
+
+cc_library(
+    name = "OgrePaging_library",
+    srcs = glob([
+        "Components/Paging/src/*.cpp",
+    ]),
+    hdrs = glob(["Components/Paging/include/*.h"]),
+    includes = [
+        "Components/Paging/include",
+        "Components/Paging/src",
+    ],
+    deps = OGRE_PAGING_DEPS.values(),
+)
+
+cc_shared_library(
+    name = "OgrePaging",
+    dynamic_deps = OGRE_PAGING_DEPS.keys(),
+    exports_filter = [":OgrePaging_library"],
+    deps = [":OgrePaging_library"],
+)
+
+### Component: OgreProperty
+
+genrule(
+    name = "OgrePropertyPrerequisites_h",
+    outs = ["Components/Property/include/OgrePropertyPrerequisites.h"],
+    cmd = "echo '#ifndef __OgrePropertyPrerequisites_H__' > $@ && " +
+          "echo '#define __OgrePropertyPrerequisites_H__' >> $@ && " +
+          "echo '#include \"OgrePrerequisites.h\"' >> $@ && " +
+          "echo '#define _OgrePropertyExport' >> $@ && " +
+          "echo '#endif' >> $@",
+)
+
+OGRE_PROPERTY_DEPS = {
+    ":OgreMain": "OgreMain_library",
+}
+
+cc_library(
+    name = "OgreProperty_library",
+    srcs = glob([
+        "Components/Property/src/*.cpp",
+    ]),
+    hdrs = glob(["Components/Property/include/*.h"]) + [
+        ":OgrePropertyPrerequisites_h",
+    ],
+    includes = [
+        "Components/Property/include",
+        "Components/Property/src",
+    ],
+    deps = OGRE_PROPERTY_DEPS.values(),
+)
+
+cc_shared_library(
+    name = "OgreProperty",
+    dynamic_deps = OGRE_PROPERTY_DEPS.keys(),
+    exports_filter = [":OgreProperty_library"],
+    deps = [":OgreProperty_library"],
+)
+
+### Component: RTShaderSystem
+
+OGRE_RT_SHADER_SYSTEM_DEPS = {
+    ":OgreMain": "OgreMain_library",
+}
+
+genrule(
+    name = "OgreRTShaderExports_h",
+    outs = ["Components/RTShaderSystem/include/OgreRTShaderExports.h"],
+    cmd = "echo '#ifndef __OgreRTShaderExports_H__' > $@ && " +
+          "echo '#define __OgreRTShaderExports_H__' >> $@ && " +
+          "echo '#include \"OgrePrerequisites.h\"' >> $@ && " +
+          "echo '#define _OgreRTSSExport' >> $@ && " +
+          "echo '#endif' >> $@",
+)
+
+cc_library(
+    name = "OgreRTShaderSystem_library",
+    srcs = glob([
+        "Components/RTShaderSystem/src/*.cpp",
+        "Components/RTShaderSystem/src/*.h",
+    ]),
+    hdrs = glob(["Components/RTShaderSystem/include/*.h"]) + [
+        ":OgreRTShaderExports_h",
+    ],
+    includes = [
+        "Components/RTShaderSystem/include",
+        "Components/RTShaderSystem/src",
+    ],
+    deps = OGRE_RT_SHADER_SYSTEM_DEPS.values(),
+)
+
+cc_shared_library(
+    name = "OgreRTShaderSystem",
+    dynamic_deps = OGRE_RT_SHADER_SYSTEM_DEPS.keys(),
+    exports_filter = [":OgreRTShaderSystem_library"],
+    deps = [":OgreRTShaderSystem_library"],
+)
+
+### Component: Terrain
+
+OGRE_TERRAIN_DEPS = {
+    ":OgreMain": "OgreMain_library",
+    ":OgrePaging": "OgrePaging_library",
+}
+
+cc_library(
+    name = "OgreTerrain_library",
+    srcs = glob([
+        "Components/Terrain/src/*.cpp",
+        "Components/Terrain/src/*.h",
+    ]),
+    hdrs = glob(["Components/Terrain/include/*.h"]),
+    includes = [
+        "Components/Terrain/include",
+        "Components/Terrain/src",
+    ],
+    deps = OGRE_TERRAIN_DEPS.values(),
+)
+
+cc_shared_library(
+    name = "OgreTerrain",
+    dynamic_deps = OGRE_TERRAIN_DEPS.keys(),
+    exports_filter = [":OgreTerrain_library"],
+    deps = [":OgreTerrain_library"],
+)
+
+### Component: Volume
+
+OGRE_VOLUME_DEPS = {
+    ":OgreMain": ":OgreMain_library",
+}
+
+genrule(
+    name = "OgreVolumePrerequisites_h",
+    outs = ["Components/Volume/include/OgreVolumePrerequisites.h"],
+    cmd = "echo '#ifndef __OgreVolumePrerequisites_H__' > $@ && " +
+          "echo '#define __OgreVolumePrerequisites_H__' >> $@ && " +
+          "echo '#include \"OgrePrerequisites.h\"' >> $@ && " +
+          "echo '#define _OgreVolumeExport' >> $@ && " +
+          "echo '#endif' >> $@",
+)
+
+cc_library(
+    name = "OgreVolume_library",
+    srcs = glob([
+        "Components/Volume/src/*.cpp",
+    ]),
+    hdrs = glob(["Components/Volume/include/*.h"]) + [
+        ":OgreVolumePrerequisites_h",
+    ],
+    includes = [
+        "Components/Volume/include",
+        "Components/Volume/src",
+    ],
+    deps = OGRE_VOLUME_DEPS.values(),
+)
+
+cc_shared_library(
+    name = "OgreVolume",
+    dynamic_deps = OGRE_VOLUME_DEPS.keys(),
+    exports_filter = [":OgreVolume_library"],
+    deps = [":OgreVolume_library"],
+)
+
+### Component: Overlay
+
+OGRE_OVERLAY_DEPS = {
+    ":OgreMain": ":OgreMain_library",
+}
+
+genrule(
+    name = "OgreOverlayPrerequisites_h",
+    outs = ["Components/Overlay/include/OgreOverlayPrerequisites.h"],
+    cmd = "echo '#ifndef __OgreOverlayPrerequisites_H__' > $@ && " +
+          "echo '#define __OgreOverlayPrerequisites_H__' >> $@ && " +
+          "echo '#include \"OgrePrerequisites.h\"' >> $@ && " +
+          "echo '#define _OgreOverlayExport' >> $@ && " +
+          "echo '#endif' >> $@",
+)
+
+genrule(
+    name = "char_traits_patch_h",
+    outs = ["Components/Overlay/include/char_traits_patch.h"],
+    cmd = "echo '#ifndef CHAR_TRAITS_PATCH_H' > $@ && " +
+          "echo '#define CHAR_TRAITS_PATCH_H' >> $@ && " +
+          "echo '#ifdef __cplusplus' >> $@ && " +
+          "echo '#include <cstddef>' >> $@ && " +
+          "echo '#else' >> $@ && " +
+          "echo '#include <stddef.h>' >> $@ && " +
+          "echo '#endif' >> $@ && " +
+          "echo 'typedef ptrdiff_t GLintptr;' >> $@ && " +
+          "echo 'typedef ptrdiff_t GLsizeiptr;' >> $@ && " +
+          "echo '#ifdef __cplusplus' >> $@ && " +
+          "echo '#include <string>' >> $@ && " +
+          "echo '#include <cstring>' >> $@ && " +
+          "echo 'namespace std {' >> $@ && " +
+          "echo '  template<>' >> $@ && " +
+          "echo '  struct char_traits<unsigned short> {' >> $@ && " +
+          "echo '    typedef unsigned short char_type;' >> $@ && " +
+          "echo '    typedef int int_type;' >> $@ && " +
+          "echo '    typedef streamoff off_type;' >> $@ && " +
+          "echo '    typedef streampos pos_type;' >> $@ && " +
+          "echo '    typedef mbstate_t state_type;' >> $@ && " +
+          "echo '    static void assign(char_type& c1, const char_type& c2) noexcept { c1 = c2; }' >> $@ && " +
+          "echo '    static constexpr bool eq(char_type c1, char_type c2) noexcept { return c1 == c2; }' >> $@ && " +
+          "echo '    static constexpr bool lt(char_type c1, char_type c2) noexcept { return c1 < c2; }' >> $@ && " +
+          "echo '    static int compare(const char_type* s1, const char_type* s2, size_t n) { for (size_t i = 0; i < n; ++i) if (s1[i] != s2[i]) return s1[i] < s2[i] ? -1 : 1; return 0; }' >> $@ && " +
+          "echo '    static size_t length(const char_type* s) { size_t len = 0; while (s[len]) ++len; return len; }' >> $@ && " +
+          "echo '    static const char_type* find(const char_type* s, size_t n, const char_type& a) { for (size_t i = 0; i < n; ++i) if (s[i] == a) return s + i; return nullptr; }' >> $@ && " +
+          "echo '    static char_type* move(char_type* s1, const char_type* s2, size_t n) { return (char_type*)std::memmove(s1, s2, n * sizeof(char_type)); }' >> $@ && " +
+          "echo '    static char_type* copy(char_type* s1, const char_type* s2, size_t n) { return (char_type*)std::memcpy(s1, s2, n * sizeof(char_type)); }' >> $@ && " +
+          "echo '    static char_type* assign(char_type* s, size_t n, char_type a) { for (size_t i = 0; i < n; ++i) s[i] = a; return s; }' >> $@ && " +
+          "echo '    static constexpr int_type not_eof(int_type e) noexcept { return e != eof() ? e : 0; }' >> $@ && " +
+          "echo '    static constexpr char_type to_char_type(int_type e) noexcept { return (char_type)e; }' >> $@ && " +
+          "echo '    static constexpr int_type to_int_type(char_type c) noexcept { return (int_type)c; }' >> $@ && " +
+          "echo '    static constexpr bool eq_int_type(int_type e1, int_type e2) noexcept { return e1 == e2; }' >> $@ && " +
+          "echo '    static constexpr int_type eof() noexcept { return -1; }' >> $@ && " +
+          "echo '  };' >> $@ && " +
+          "echo '  template<>' >> $@ && " +
+          "echo '  struct char_traits<unsigned int> {' >> $@ && " +
+          "echo '    typedef unsigned int char_type;' >> $@ && " +
+          "echo '    typedef int int_type;' >> $@ && " +
+          "echo '    typedef streamoff off_type;' >> $@ && " +
+          "echo '    typedef streampos pos_type;' >> $@ && " +
+          "echo '    typedef mbstate_t state_type;' >> $@ && " +
+          "echo '    static void assign(char_type& c1, const char_type& c2) noexcept { c1 = c2; }' >> $@ && " +
+          "echo '    static constexpr bool eq(char_type c1, char_type c2) noexcept { return c1 == c2; }' >> $@ && " +
+          "echo '    static constexpr bool lt(char_type c1, char_type c2) noexcept { return c1 < c2; }' >> $@ && " +
+          "echo '    static int compare(const char_type* s1, const char_type* s2, size_t n) { for (size_t i = 0; i < n; ++i) if (s1[i] != s2[i]) return s1[i] < s2[i] ? -1 : 1; return 0; }' >> $@ && " +
+          "echo '    static size_t length(const char_type* s) { size_t len = 0; while (s[len]) ++len; return len; }' >> $@ && " +
+          "echo '    static const char_type* find(const char_type* s, size_t n, const char_type& a) { for (size_t i = 0; i < n; ++i) if (s[i] == a) return s + i; return nullptr; }' >> $@ && " +
+          "echo '    static char_type* move(char_type* s1, const char_type* s2, size_t n) { return (char_type*)std::memmove(s1, s2, n * sizeof(char_type)); }' >> $@ && " +
+          "echo '    static char_type* copy(char_type* s1, const char_type* s2, size_t n) { return (char_type*)std::memcpy(s1, s2, n * sizeof(char_type)); }' >> $@ && " +
+          "echo '    static char_type* assign(char_type* s, size_t n, char_type a) { for (size_t i = 0; i < n; ++i) s[i] = a; return s; }' >> $@ && " +
+          "echo '    static constexpr int_type not_eof(int_type e) noexcept { return e != eof() ? e : 0; }' >> $@ && " +
+          "echo '    static constexpr char_type to_char_type(int_type e) noexcept { return (char_type)e; }' >> $@ && " +
+          "echo '    static constexpr int_type to_int_type(char_type c) noexcept { return (int_type)c; }' >> $@ && " +
+          "echo '    static constexpr bool eq_int_type(int_type e1, int_type e2) noexcept { return e1 == e2; }' >> $@ && " +
+          "echo '    static constexpr int_type eof() noexcept { return -1; }' >> $@ && " +
+          "echo '  };' >> $@ && " +
+          "echo '}' >> $@ && " +
+          "echo '#endif' >> $@ && " +
+          "echo '#endif' >> $@",
+)
+
+cc_library(
+    name = "OgreOverlay_library",
+    srcs = glob([
+        "Components/Overlay/src/*.cpp",
+        "Components/Overlay/src/*.h",
+    ]),
+    hdrs = glob(["Components/Overlay/include/*.h"]) + [
+        ":OgreOverlayPrerequisites_h",
+        ":char_traits_patch_h",
+    ],
+    copts = select({
+        "@platforms//os:windows": ["/FIchar_traits_patch.h"],
+        "//conditions:default": ["-include char_traits_patch.h"],
+    }),
+    includes = [
+        "Components/Overlay/include",
+        "Components/Overlay/src",
+    ],
+    deps = OGRE_OVERLAY_DEPS.values() + [
+        "@imgui",
+    ],
+)
+
+cc_shared_library(
+    name = "OgreOverlay",
+    dynamic_deps = OGRE_OVERLAY_DEPS.keys(),
+    exports_filter = [
+        ":OgreOverlay_library",
+        "@imgui",
+    ],
+    deps = [":OgreOverlay_library"],
+)
+
+# Generate gl_types_patch.h to fix missing traits and types removed in clang-19.
+
+genrule(
+    name = "gl_types_patch_h",
+    outs = ["RenderSystems/GL/include/gl_types_patch.h"],
+    cmd = "echo '#ifndef GL_TYPES_PATCH_H' > $@ && " +
+          "echo '#define GL_TYPES_PATCH_H' >> $@ && " +
+          "echo '#ifdef __cplusplus' >> $@ && " +
+          "echo '#include <cstddef>' >> $@ && " +
+          "echo '#include <GL/gl.h>' >> $@ && " +
+          "echo 'typedef ptrdiff_t GLintptr;' >> $@ && " +
+          "echo 'typedef ptrdiff_t GLsizeiptr;' >> $@ && " +
+          "echo '#endif' >> $@ && " +
+          "echo '#endif' >> $@",
+)
+
+cc_library(
+    name = "RenderSystems",
+    hdrs = glob([
+        "RenderSystems/GL/include/**/*.h",
+        "RenderSystems/GL/src/GLSL/include/**/*.h",
+    ]) + [
+        ":gl_types_patch_h",
+    ],
+    copts = select({
+        "@platforms//os:windows": ["/FIgl_types_patch.h"],
+        "//conditions:default": ["-include gl_types_patch.h"],
+    }),
+    implementation_deps = [
+        "@glew",
+    ],
+    includes = [
+        "RenderSystems/GL/include",
+        "RenderSystems/GL/include/GL",
+        "RenderSystems/GL/src",
+    ],
+    deps = [
+        "@egl-registry//:EGL_headers",
+        "@opengl-registry//:OpenGL_headers",
+    ],
+)
+
+### RenderSystem: GLSupport
+
+genrule(
+    name = "OgreGLSupportPrerequisites_h",
+    outs = ["RenderSystems/GLSupport/include/OgreGLSupportPrerequisites.h"],
+    cmd = "echo '#ifndef __OgreGLSupportPrerequisites_H__' > $@ && " +
+          "echo '#define __OgreGLSupportPrerequisites_H__' >> $@ && " +
+          "echo '#include \"OgrePrerequisites.h\"' >> $@ && " +
+          "echo '#define _OgreGLExport' >> $@ && " +
+          "echo '#endif' >> $@",
+)
+
+# GL/glx.h itself was removed from the Khronos OpenGL-Registry (same story
+# as gl.h, already vendored the same way by opengl-registry's own overlay
+# -- see its "gl_h" target) -- vendored here from Mesa, the same canonical
+# source and commit opengl-registry used for gl.h. GLX itself only exists
+# on X11/Linux, so this (and everything that needs it) is Linux-only;
+# glxext.h is unaffected and still comes from @opengl-registry.
+cc_library(
+    name = "glx_headers",
+    hdrs = ["glx.h"],
+    include_prefix = "GL",
+    linkopts = ["-lGL"],
+    target_compatible_with = ["@platforms//os:linux"],
+)
+
+cc_library(
+    name = "RenderSystem_GLSupport",
+    srcs = glob([
+        "RenderSystems/GLSupport/src/EGL/*.cpp",
+        "RenderSystems/GLSupport/src/GLSL/*.cpp",
+        "RenderSystems/GLSupport/src/*.cpp",
+    ]) + select({
+        "@platforms//os:windows": glob([
+            "RenderSystems/GLSupport/src/win32/*.cpp",
+        ]),
+        "@platforms//os:osx": glob([
+            "RenderSystems/GLSupport/src/OSX/*.cpp",
+        ]),
+        "@platforms//os:linux": glob([
+            "RenderSystems/GLSupport/src/GLX/*.cpp",
+        ]),
+        "//conditions:default": [],
+    }),
+    hdrs = glob([
+        "RenderSystems/GLSupport/include/EGL/*.h",
+        "RenderSystems/GLSupport/include/GLSL/*.h",
+        "RenderSystems/GLSupport/include/*.h",
+    ]) + [
+        ":OgreGLSupportPrerequisites_h",
+    ] + select({
+        "@platforms//os:windows": glob([
+            "RenderSystems/GLSupport/include/win32/*.h",
+        ]),
+        "@platforms//os:osx": glob([
+            "RenderSystems/GLSupport/include/OSX/*.h",
+        ]),
+        "@platforms//os:linux": glob([
+            "RenderSystems/GLSupport/include/GLX/*.h",
+        ]),
+        "//conditions:default": [],
+    }),
+    implementation_deps = [
+        "@egl-registry//:EGL_headers",
+        "@opengl-registry//:OpenGL_headers",
+    ],
+    includes = [
+        "RenderSystems/GLSupport/include",
+        "RenderSystems/GLSupport/include/EGL",
+        "RenderSystems/GLSupport/include/GLSL",
+    ] + select({
+        "@platforms//os:windows": [
+            "RenderSystems/GLSupport/include/win32",
+        ],
+        "@platforms//os:osx": [
+            "RenderSystems/GLSupport/include/OSX",
+        ],
+        "@platforms//os:linux": [
+            "RenderSystems/GLSupport/include/GLX",
+        ],
+        "//conditions:default": [],
+    }),
+    linkopts = select({
+        "@platforms//os:osx": [
+            "-framework",
+            "OpenGL",
+            "-framework",
+            "Cocoa",
+        ],
+        "//conditions:default": [],
+    }),
+    deps = [
+        ":OgreMain_library",
+        "@libx11",
+        "@libxcb",
+        "@libxrandr",
+    ] + select({
+        "@platforms//os:linux": [":glx_headers"],
+        "//conditions:default": [],
+    }),
+)
+
+### RenderSystem: GL
+
+OGRE_RENDERSYSTEM_GL_DEPS = {
+    ":OgreMain": ":OgreMain_library",
+}
+
+cc_library(
+    name = "RenderSystem_GL_library",
+    srcs = glob(
+        [
+            "RenderSystems/GL/src/**/*.c",
+            "RenderSystems/GL/src/**/*.cpp",
+            "RenderSystems/GL/src/**/*.h",
+        ],
+        exclude = [
+            "RenderSystems/GL/src/nvparse/ps1.0__test_main.cpp",
+        ],
+    ),
+    hdrs = glob(
+        ["RenderSystems/GL/include/**/*.h"],
+    ),
+    includes = [
+        "RenderSystems/GL/include",
+        "RenderSystems/GL/include/GL",
+        "RenderSystems/GL/src",
+        "RenderSystems/GL/src/GLSL/include",
+        "RenderSystems/GL/src/atifs/include",
+        "RenderSystems/GL/src/nvparse",
+    ],
+    deps = OGRE_RENDERSYSTEM_GL_DEPS.values() + [
+        ":RenderSystem_GLSupport",
+        "@glew",
+    ],
+)
+
+cc_shared_library(
+    name = "RenderSystem_GL",
+    dynamic_deps = OGRE_RENDERSYSTEM_GL_DEPS.keys(),
+    exports_filter = [
+        ":RenderSystem_GL_library",
+        ":RenderSystem_GLSupport",
+        "@glew//:glew",
+    ],
+    deps = [":RenderSystem_GL_library"],
+)
+
+### RenderSystem: GL3Plus
+
+OGRE_RENDERSYSTEM_GL3PLUS_DEPS = {
+    ":OgreMain": ":OgreMain_library",
+}
+
+cc_library(
+    name = "RenderSystem_GL3Plus_library",
+    srcs = glob([
+        "RenderSystems/GL3Plus/src/**/*.c",
+        "RenderSystems/GL3Plus/src/**/*.cpp",
+        "RenderSystems/GL3Plus/src/**/*.h",
+    ]),
+    hdrs = glob(["RenderSystems/GL3Plus/include/**/*.h"]),
+    includes = [
+        "RenderSystems/GL3Plus/include",
+        "RenderSystems/GL3Plus/src",
+        "RenderSystems/GL3Plus/src/GLSL/include",
+    ],
+    deps = OGRE_RENDERSYSTEM_GL3PLUS_DEPS.values() + [
+        ":RenderSystem_GLSupport",
+    ],
+)
+
+cc_shared_library(
+    name = "RenderSystem_GL3Plus",
+    dynamic_deps = OGRE_RENDERSYSTEM_GL3PLUS_DEPS.keys(),
+    exports_filter = [
+        ":RenderSystem_GL3Plus_library",
+        ":RenderSystem_GLSupport",
+    ],
+    deps = [":RenderSystem_GL3Plus_library"],
+)
+
+### PlugIn: STBICodec
+
+OGRE_CODEC_STBI_DEPS = {
+    ":OgreMain": ":OgreMain_library",
+}
+
+genrule(
+    name = "OgreSTBICodecExports_h",
+    outs = ["PlugIns/STBICodec/include/OgreSTBICodecExports.h"],
+    cmd = "echo '#ifndef __OgreSTBICodecExports_H__' > $@ && " +
+          "echo '#define __OgreSTBICodecExports_H__' >> $@ && " +
+          "echo '#include \"OgrePrerequisites.h\"' >> $@ && " +
+          "echo '#define _OgreSTBICodecExport' >> $@ && " +
+          "echo '#endif' >> $@",
+)
+
+cc_library(
+    name = "Codec_STBI_library",
+    srcs = glob(
+        [
+            "PlugIns/STBICodec/src/**/*.cpp",
+            "PlugIns/STBICodec/src/**/*.h",
+        ],
+        allow_empty = True,
+    ),
+    hdrs = glob(
+        ["PlugIns/STBICodec/include/*.h"],
+        allow_empty = True,
+    ) + [
+        ":OgreSTBICodecExports_h",
+    ],
+    copts = select({
+        "@platforms//os:windows": [],
+        "//conditions:default": [
+            "-Wno-cast-qual",
+            "-Wno-unused-function",
+            "-Wno-missing-declarations",
+        ],
+    }),
+    includes = [
+        "PlugIns/STBICodec/include",
+        "PlugIns/STBICodec/src",
+    ],
+    deps = OGRE_CODEC_STBI_DEPS.values(),
+)
+
+cc_shared_library(
+    name = "Codec_STBI",
+    dynamic_deps = OGRE_CODEC_STBI_DEPS.keys(),
+    exports_filter = [":Codec_STBI_library"],
+    deps = [":Codec_STBI_library"],
+)

--- a/bcr_staging/modules/ogre/1.12.10.rcr.0/overlay/glx.h
+++ b/bcr_staging/modules/ogre/1.12.10.rcr.0/overlay/glx.h
@@ -1,0 +1,371 @@
+/*
+ * Mesa 3-D graphics library
+ * 
+ * Copyright (C) 1999-2006  Brian Paul   All Rights Reserved.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
+#ifndef GLX_H
+#define GLX_H
+
+
+#include <X11/Xlib.h>
+#include <X11/Xutil.h>
+#include <GL/gl.h>
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+#define GLX_VERSION_1_1		1
+#define GLX_VERSION_1_2		1
+#define GLX_VERSION_1_3		1
+#define GLX_VERSION_1_4		1
+
+#define GLX_EXTENSION_NAME   "GLX"
+
+
+
+/*
+ * Tokens for glXChooseVisual and glXGetConfig:
+ */
+#define GLX_USE_GL		1
+#define GLX_BUFFER_SIZE		2
+#define GLX_LEVEL		3
+#define GLX_RGBA		4
+#define GLX_DOUBLEBUFFER	5
+#define GLX_STEREO		6
+#define GLX_AUX_BUFFERS		7
+#define GLX_RED_SIZE		8
+#define GLX_GREEN_SIZE		9
+#define GLX_BLUE_SIZE		10
+#define GLX_ALPHA_SIZE		11
+#define GLX_DEPTH_SIZE		12
+#define GLX_STENCIL_SIZE	13
+#define GLX_ACCUM_RED_SIZE	14
+#define GLX_ACCUM_GREEN_SIZE	15
+#define GLX_ACCUM_BLUE_SIZE	16
+#define GLX_ACCUM_ALPHA_SIZE	17
+
+
+/*
+ * Error codes returned by glXGetConfig:
+ */
+#define GLX_BAD_SCREEN		1
+#define GLX_BAD_ATTRIBUTE	2
+#define GLX_NO_EXTENSION	3
+#define GLX_BAD_VISUAL		4
+#define GLX_BAD_CONTEXT		5
+#define GLX_BAD_VALUE       	6
+#define GLX_BAD_ENUM		7
+
+
+/*
+ * GLX 1.1 and later:
+ */
+#define GLX_VENDOR		1
+#define GLX_VERSION		2
+#define GLX_EXTENSIONS 		3
+
+
+/*
+ * GLX 1.3 and later:
+ */
+#define GLX_CONFIG_CAVEAT		0x20
+#define GLX_DONT_CARE			0xFFFFFFFF
+#define GLX_X_VISUAL_TYPE		0x22
+#define GLX_TRANSPARENT_TYPE		0x23
+#define GLX_TRANSPARENT_INDEX_VALUE	0x24
+#define GLX_TRANSPARENT_RED_VALUE	0x25
+#define GLX_TRANSPARENT_GREEN_VALUE	0x26
+#define GLX_TRANSPARENT_BLUE_VALUE	0x27
+#define GLX_TRANSPARENT_ALPHA_VALUE	0x28
+#define GLX_WINDOW_BIT			0x00000001
+#define GLX_PIXMAP_BIT			0x00000002
+#define GLX_PBUFFER_BIT			0x00000004
+#define GLX_AUX_BUFFERS_BIT		0x00000010
+#define GLX_FRONT_LEFT_BUFFER_BIT	0x00000001
+#define GLX_FRONT_RIGHT_BUFFER_BIT	0x00000002
+#define GLX_BACK_LEFT_BUFFER_BIT	0x00000004
+#define GLX_BACK_RIGHT_BUFFER_BIT	0x00000008
+#define GLX_DEPTH_BUFFER_BIT		0x00000020
+#define GLX_STENCIL_BUFFER_BIT		0x00000040
+#define GLX_ACCUM_BUFFER_BIT		0x00000080
+#define GLX_NONE			0x8000
+#define GLX_SLOW_CONFIG			0x8001
+#define GLX_TRUE_COLOR			0x8002
+#define GLX_DIRECT_COLOR		0x8003
+#define GLX_PSEUDO_COLOR		0x8004
+#define GLX_STATIC_COLOR		0x8005
+#define GLX_GRAY_SCALE			0x8006
+#define GLX_STATIC_GRAY			0x8007
+#define GLX_TRANSPARENT_RGB		0x8008
+#define GLX_TRANSPARENT_INDEX		0x8009
+#define GLX_VISUAL_ID			0x800B
+#define GLX_SCREEN			0x800C
+#define GLX_NON_CONFORMANT_CONFIG	0x800D
+#define GLX_DRAWABLE_TYPE		0x8010
+#define GLX_RENDER_TYPE			0x8011
+#define GLX_X_RENDERABLE		0x8012
+#define GLX_FBCONFIG_ID			0x8013
+#define GLX_RGBA_TYPE			0x8014
+#define GLX_COLOR_INDEX_TYPE		0x8015
+#define GLX_MAX_PBUFFER_WIDTH		0x8016
+#define GLX_MAX_PBUFFER_HEIGHT		0x8017
+#define GLX_MAX_PBUFFER_PIXELS		0x8018
+#define GLX_PRESERVED_CONTENTS		0x801B
+#define GLX_LARGEST_PBUFFER		0x801C
+#define GLX_WIDTH			0x801D
+#define GLX_HEIGHT			0x801E
+#define GLX_EVENT_MASK			0x801F
+#define GLX_DAMAGED			0x8020
+#define GLX_SAVED			0x8021
+#define GLX_WINDOW			0x8022
+#define GLX_PBUFFER			0x8023
+#define GLX_PBUFFER_HEIGHT              0x8040
+#define GLX_PBUFFER_WIDTH               0x8041
+#define GLX_RGBA_BIT			0x00000001
+#define GLX_COLOR_INDEX_BIT		0x00000002
+#define GLX_PBUFFER_CLOBBER_MASK	0x08000000
+
+
+/*
+ * GLX 1.4 and later:
+ */
+#define GLX_SAMPLE_BUFFERS              0x186a0 /*100000*/
+#define GLX_SAMPLES                     0x186a1 /*100001*/
+
+
+
+typedef struct __GLXcontextRec *GLXContext;
+typedef XID GLXPixmap;
+typedef XID GLXDrawable;
+/* GLX 1.3 and later */
+typedef struct __GLXFBConfigRec *GLXFBConfig;
+typedef XID GLXFBConfigID;
+typedef XID GLXContextID;
+typedef XID GLXWindow;
+typedef XID GLXPbuffer;
+
+
+/*
+** Events.
+** __GLX_NUMBER_EVENTS is set to 17 to account for the BufferClobberSGIX
+**  event - this helps initialization if the server supports the pbuffer
+**  extension and the client doesn't.
+*/
+#define GLX_PbufferClobber	0
+#define GLX_BufferSwapComplete	1
+
+#define __GLX_NUMBER_EVENTS 17
+
+extern XVisualInfo* glXChooseVisual( Display *dpy, int screen,
+				     int *attribList );
+
+extern GLXContext glXCreateContext( Display *dpy, XVisualInfo *vis,
+				    GLXContext shareList, Bool direct );
+
+extern void glXDestroyContext( Display *dpy, GLXContext ctx );
+
+extern Bool glXMakeCurrent( Display *dpy, GLXDrawable drawable,
+			    GLXContext ctx);
+
+extern void glXCopyContext( Display *dpy, GLXContext src, GLXContext dst,
+			    unsigned long mask );
+
+extern void glXSwapBuffers( Display *dpy, GLXDrawable drawable );
+
+extern GLXPixmap glXCreateGLXPixmap( Display *dpy, XVisualInfo *visual,
+				     Pixmap pixmap );
+
+extern void glXDestroyGLXPixmap( Display *dpy, GLXPixmap pixmap );
+
+extern Bool glXQueryExtension( Display *dpy, int *errorb, int *event );
+
+extern Bool glXQueryVersion( Display *dpy, int *maj, int *min );
+
+extern Bool glXIsDirect( Display *dpy, GLXContext ctx );
+
+extern int glXGetConfig( Display *dpy, XVisualInfo *visual,
+			 int attrib, int *value );
+
+extern GLXContext glXGetCurrentContext( void );
+
+extern GLXDrawable glXGetCurrentDrawable( void );
+
+extern void glXWaitGL( void );
+
+extern void glXWaitX( void );
+
+extern void glXUseXFont( Font font, int first, int count, int list );
+
+
+
+/* GLX 1.1 and later */
+extern const char *glXQueryExtensionsString( Display *dpy, int screen );
+
+extern const char *glXQueryServerString( Display *dpy, int screen, int name );
+
+extern const char *glXGetClientString( Display *dpy, int name );
+
+
+/* GLX 1.2 and later */
+extern Display *glXGetCurrentDisplay( void );
+
+
+/* GLX 1.3 and later */
+extern GLXFBConfig *glXChooseFBConfig( Display *dpy, int screen,
+                                       const int *attribList, int *nitems );
+
+extern int glXGetFBConfigAttrib( Display *dpy, GLXFBConfig config,
+                                 int attribute, int *value );
+
+extern GLXFBConfig *glXGetFBConfigs( Display *dpy, int screen,
+                                     int *nelements );
+
+extern XVisualInfo *glXGetVisualFromFBConfig( Display *dpy,
+                                              GLXFBConfig config );
+
+extern GLXWindow glXCreateWindow( Display *dpy, GLXFBConfig config,
+                                  Window win, const int *attribList );
+
+extern void glXDestroyWindow( Display *dpy, GLXWindow window );
+
+extern GLXPixmap glXCreatePixmap( Display *dpy, GLXFBConfig config,
+                                  Pixmap pixmap, const int *attribList );
+
+extern void glXDestroyPixmap( Display *dpy, GLXPixmap pixmap );
+
+extern GLXPbuffer glXCreatePbuffer( Display *dpy, GLXFBConfig config,
+                                    const int *attribList );
+
+extern void glXDestroyPbuffer( Display *dpy, GLXPbuffer pbuf );
+
+extern void glXQueryDrawable( Display *dpy, GLXDrawable draw, int attribute,
+                              unsigned int *value );
+
+extern GLXContext glXCreateNewContext( Display *dpy, GLXFBConfig config,
+                                       int renderType, GLXContext shareList,
+                                       Bool direct );
+
+extern Bool glXMakeContextCurrent( Display *dpy, GLXDrawable draw,
+                                   GLXDrawable read, GLXContext ctx );
+
+extern GLXDrawable glXGetCurrentReadDrawable( void );
+
+extern int glXQueryContext( Display *dpy, GLXContext ctx, int attribute,
+                            int *value );
+
+extern void glXSelectEvent( Display *dpy, GLXDrawable drawable,
+                            unsigned long mask );
+
+extern void glXGetSelectedEvent( Display *dpy, GLXDrawable drawable,
+                                 unsigned long *mask );
+
+/* GLX 1.3 function pointer typedefs */
+typedef GLXFBConfig * (* PFNGLXGETFBCONFIGSPROC) (Display *dpy, int screen, int *nelements);
+typedef GLXFBConfig * (* PFNGLXCHOOSEFBCONFIGPROC) (Display *dpy, int screen, const int *attrib_list, int *nelements);
+typedef int (* PFNGLXGETFBCONFIGATTRIBPROC) (Display *dpy, GLXFBConfig config, int attribute, int *value);
+typedef XVisualInfo * (* PFNGLXGETVISUALFROMFBCONFIGPROC) (Display *dpy, GLXFBConfig config);
+typedef GLXWindow (* PFNGLXCREATEWINDOWPROC) (Display *dpy, GLXFBConfig config, Window win, const int *attrib_list);
+typedef void (* PFNGLXDESTROYWINDOWPROC) (Display *dpy, GLXWindow win);
+typedef GLXPixmap (* PFNGLXCREATEPIXMAPPROC) (Display *dpy, GLXFBConfig config, Pixmap pixmap, const int *attrib_list);
+typedef void (* PFNGLXDESTROYPIXMAPPROC) (Display *dpy, GLXPixmap pixmap);
+typedef GLXPbuffer (* PFNGLXCREATEPBUFFERPROC) (Display *dpy, GLXFBConfig config, const int *attrib_list);
+typedef void (* PFNGLXDESTROYPBUFFERPROC) (Display *dpy, GLXPbuffer pbuf);
+typedef void (* PFNGLXQUERYDRAWABLEPROC) (Display *dpy, GLXDrawable draw, int attribute, unsigned int *value);
+typedef GLXContext (* PFNGLXCREATENEWCONTEXTPROC) (Display *dpy, GLXFBConfig config, int render_type, GLXContext share_list, Bool direct);
+typedef Bool (* PFNGLXMAKECONTEXTCURRENTPROC) (Display *dpy, GLXDrawable draw, GLXDrawable read, GLXContext ctx);
+typedef GLXDrawable (* PFNGLXGETCURRENTREADDRAWABLEPROC) (void);
+typedef Display * (* PFNGLXGETCURRENTDISPLAYPROC) (void);
+typedef int (* PFNGLXQUERYCONTEXTPROC) (Display *dpy, GLXContext ctx, int attribute, int *value);
+typedef void (* PFNGLXSELECTEVENTPROC) (Display *dpy, GLXDrawable draw, unsigned long event_mask);
+typedef void (* PFNGLXGETSELECTEDEVENTPROC) (Display *dpy, GLXDrawable draw, unsigned long *event_mask);
+
+
+/*
+ * ARB 2. GLX_ARB_get_proc_address
+ */
+#ifndef GLX_ARB_get_proc_address
+#define GLX_ARB_get_proc_address 1
+
+typedef void (*__GLXextFuncPtr)(void);
+extern __GLXextFuncPtr glXGetProcAddressARB (const GLubyte *);
+
+#endif /* GLX_ARB_get_proc_address */
+
+
+
+/* GLX 1.4 and later */
+extern void (*glXGetProcAddress(const GLubyte *procname))( void );
+
+/* GLX 1.4 function pointer typedefs */
+typedef __GLXextFuncPtr (* PFNGLXGETPROCADDRESSPROC) (const GLubyte *procName);
+
+
+#ifndef GLX_GLXEXT_LEGACY
+#include <GL/glxext.h>
+#endif /* GLX_GLXEXT_LEGACY */
+
+
+/*** Should these go here, or in another header? */
+/*
+** GLX Events
+*/
+typedef struct {
+    int event_type;		/* GLX_DAMAGED or GLX_SAVED */
+    int draw_type;		/* GLX_WINDOW or GLX_PBUFFER */
+    unsigned long serial;	/* # of last request processed by server */
+    Bool send_event;		/* true if this came for SendEvent request */
+    Display *display;		/* display the event was read from */
+    GLXDrawable drawable;	/* XID of Drawable */
+    unsigned int buffer_mask;	/* mask indicating which buffers are affected */
+    unsigned int aux_buffer;	/* which aux buffer was affected */
+    int x, y;
+    int width, height;
+    int count;			/* if nonzero, at least this many more */
+} GLXPbufferClobberEvent;
+
+typedef struct {
+    int type;
+    unsigned long serial;	/* # of last request processed by server */
+    Bool send_event;		/* true if this came from a SendEvent request */
+    Display *display;		/* Display the event was read from */
+    Drawable drawable;	/* drawable on which event was requested in event mask */
+    int event_type;
+    int64_t ust;
+    int64_t msc;
+    int64_t sbc;
+} GLXBufferSwapComplete;
+
+typedef union __GLXEvent {
+    GLXPbufferClobberEvent glxpbufferclobber;
+    GLXBufferSwapComplete glxbufferswapcomplete;
+    long pad[24];
+} GLXEvent;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/bcr_staging/modules/ogre/1.12.10.rcr.0/presubmit.yml
+++ b/bcr_staging/modules/ogre/1.12.10.rcr.0/presubmit.yml
@@ -1,0 +1,32 @@
+build_targets: &build_targets
+  - "@ogre//..."
+matrix:
+  unix_platforms:
+    - ubuntu2404
+    - ubuntu2404_arm64
+    - macos
+    - macos_arm64
+  windows_platforms:
+    - windows
+    - windows_arm64
+  bazel:
+    - 7.x
+    - 8.x
+    - 9.x
+tasks:
+  verify_targets_unix:
+    name: Verify build targets on Unix
+    platform: ${{ unix_platforms }}
+    bazel: ${{ bazel }}
+    build_flags:
+      - "--cxxopt=-std=c++17"
+      - "--host_cxxopt=-std=c++17"
+    build_targets: *build_targets
+  verify_targets_windows:
+    name: Verify build targets on Windows
+    platform: ${{ windows_platforms }}
+    bazel: ${{ bazel }}
+    build_flags:
+      - "--cxxopt=/std:c++17"
+      - "--host_cxxopt=/std:c++17"
+    build_targets: *build_targets

--- a/bcr_staging/modules/ogre/1.12.10.rcr.0/source.json
+++ b/bcr_staging/modules/ogre/1.12.10.rcr.0/source.json
@@ -1,0 +1,9 @@
+{
+    "url": "https://github.com/OGRECave/ogre/archive/refs/tags/v1.12.10.tar.gz",
+    "integrity": "sha256-1PeR5sTfkwfvuOTpJlIjP5SOoG1eIuBl8pnJq4/Fz6Q=",
+    "strip_prefix": "ogre-1.12.10",
+    "overlay": {
+        "BUILD.bazel": "sha256-VLM9zvgqxswyl5NcRV8EMDrabnId1SAR9GdjkEYzGM8=",
+        "glx.h": "sha256-JTBor46mw6jxBD0XRFfQA6SOz0C+1mY/TSHrDg1WbeA="
+    }
+}

--- a/bcr_staging/modules/ogre/metadata.json
+++ b/bcr_staging/modules/ogre/metadata.json
@@ -12,7 +12,8 @@
         "github:OGRECave/ogre"
     ],
     "versions": [
-        "1.12.10"
+        "1.12.10",
+        "1.12.10.rcr.0"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
## Summary

Two independent, previously latent bugs in `bcr_staging/modules/ogre`, surfaced while unblocking PR #156's CI. Both were masked because ogre had never actually been rebuilt from scratch on this repo's CI -- it was coasting on stale remote-cache hits until #156's `rosdistro` `MODULE.bazel` change invalidated the relevant cache entries.

- `RenderSystem_GLSupport`'s `GLX/*.cpp` sources were compiled unconditionally on every OS (only `win32`/`osx` got extra platform-specific files via `select()`), but the only GL headers wired in were `@egl-registry`/`@opengl-registry`, neither of which ships `GL/glx.h` -- Khronos removed it from OpenGL-Registry the same way it removed `gl.h` (which `opengl-registry`'s own overlay already vendors from Mesa for exactly that reason). This vendors `GL/glx.h` the same way, gates GLX sources/headers/includes to Linux only via `select()` (GLX is X11-specific; it was never meaningful on Windows/macOS to begin with), and adds `-framework OpenGL -framework Cocoa` linkopts on macOS for what's already correctly built there.

  A stub was deliberately **not** placed in `rosdistro`'s own package for `ogre` to depend on: `rosdistro` already transitively depends on `ogre` (via `gz-rendering`/`gz-sim`), so the reverse would be a cycle in the bzlmod module graph.

- `OgreMain_library` fails to compile `OgreLodStrategy.cpp` under this toolchain's libc++ with `no template named 'binary_function' in namespace 'std'` even with `-std=c++17` already set -- recent libc++ only keeps the deprecated `std::binary_function` for `_LIBCPP_STD_VER <= 14`, gated behind an explicit opt-in macro for anything higher. Adds `-D_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION` rather than patching ogre's (otherwise fine) source.

## Verification

- `@@ogre+//:RenderSystem_GLSupport` builds successfully end to end (not just analyze) from a fresh workspace, both alone and via `rosdistro`'s own `bazel_dep(ogre)` bumped to this version.
- `@rosdistro//cc:curl` (and the rest of `@rosdistro//...`) still analyzes and builds cleanly.
- `buildifier -mode=check` clean.
- `bazel run //tools/ci:check_pr_modules -- --directory bcr_staging/modules` reports no violations.

Note: this is depended on by #156 (which bumps `rosdistro`'s `bazel_dep(ogre)` to this version to actually select it) -- that PR currently carries a duplicate copy of this module version so its own CI can resolve it before this one merges; it'll deduplicate on the next rebase.

## Acknowledgements

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Code of Conduct](../CODE_OF_CONDUCT.md) and agree to abide by it.
- [x] I have read and complied with the [OSRF Policy on the Use of Generative AI Tools ("Generative AI") in Contributions](https://github.com/openrobotics/osra-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md).

## Generative AI disclosure

- Was any generative AI tool used in this contribution? Yes.
- If yes, which tool(s), and for which part(s) of the contribution? Claude Code (Sonnet 5) diagnosed both root causes (including tracing the libc++ removal to the exact gating macro and version threshold) and authored this patch and PR description, under my direction -- I specifically chose the copts-based fix over a source patch, and directed the GLX stub to live in ogre's own overlay rather than rosdistro's after flagging the module-graph cycle risk.

## Related issue(s)

- Fixes: N/A -- no tracked issue; found while unblocking CI on #156.

## Additional information

Packages affected: `ogre` (new patch version `1.12.10.rcr.0` in `bcr_staging/modules`) only.