### PR TITLE
fix: post the module-diff PR comment as soon as the modules check finishes

### DIFF
--- a/.github/workflows/check_bazel_modules.yml
+++ b/.github/workflows/check_bazel_modules.yml
@@ -1,0 +1,50 @@
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Standalone trigger for _check_bazel_modules.yml, existing solely so
+# post_module_diff_comment.yml's workflow_run listener can react to it
+# directly. workflow_run only fires on a whole top-level workflow's
+# completion -- _check_bazel_modules.yml is workflow_call-only, so it can
+# never trigger workflow_run itself, and ci.yaml (which also calls it, as
+# the "bazel_modules" job) only completes once every other job in that much
+# bigger pipeline finishes too (full distribution builds, RMW test matrix,
+# ...). That means the module-diff PR comment previously couldn't post
+# until all of that finished, even though the modules check itself is one
+# of the very first, fastest things ci.yaml runs.
+#
+# This duplicates that one (cheap: no distribution build, just a few
+# `bazel run` calls over the Python tooling) check per PR -- once here for
+# a fast comment, once inside ci.yaml to keep gating distribution_compiles
+# -- since GitHub Actions has no cross-workflow job dependency mechanism
+# that would let ci.yaml's gate depend on this workflow instead.
+
+name: check_bazel_modules
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: check-bazel-modules-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  bazel_modules:
+    name: Check modules
+    uses: ./.github/workflows/_check_bazel_modules.yml
+    secrets: inherit

--- a/.github/workflows/post_module_diff_comment.yml
+++ b/.github/workflows/post_module_diff_comment.yml
@@ -13,9 +13,14 @@
 # limitations under the License.
 
 # Posts/updates the module-diff PR comment produced by
-# _check_bazel_modules.yml (part of the `ci` workflow). This is a
-# separate, workflow_run-triggered workflow rather than a step inside
-# `ci` itself because `ci` can run against a fork PR, where GitHub forces
+# _check_bazel_modules.yml, called from the standalone check_bazel_modules
+# workflow (not ci.yaml -- see check_bazel_modules.yml's own comment for
+# why: ci.yaml's version of this same check is just one of its early,
+# fast jobs, but workflow_run only fires once a whole top-level workflow
+# completes, and ci.yaml as a whole also includes the much slower
+# distribution build/test matrix). This is a separate, workflow_run-
+# triggered workflow rather than a step inside check_bazel_modules itself
+# because both workflows can run against a fork PR, where GitHub forces
 # GITHUB_TOKEN to read-only and a direct comment attempt from within that
 # run fails with "Resource not accessible by integration".
 #
@@ -30,7 +35,7 @@ name: post_module_diff_comment
 
 on:
   workflow_run:
-    workflows: ["ci"]
+    workflows: ["check_bazel_modules"]
     types: [completed]
 
 permissions:


### PR DESCRIPTION
## Summary

`post_module_diff_comment.yml` triggers on `workflow_run` for `workflows: ["ci"]`, which only fires once the *entire* `ci` workflow completes. The modules check (`_check_bazel_modules.yml`, called as `ci.yaml`'s `bazel_modules` job) is one of the first, fastest jobs in that pipeline, but `ci` as a whole also includes the full distribution build/test matrix (`distribution_compiles`, `distribution_examples`, 4x `test_rmw_*`), which can run much longer. Net effect: the module-diff PR comment couldn't post until everything finished, not just the specific check its content depends on.

`_check_bazel_modules.yml` is `workflow_call`-only, so it can never trigger `workflow_run` itself, and GitHub Actions has no cross-workflow job dependency mechanism -- there's no way to have `ci.yaml`'s `distribution_compiles` gate depend on a separate workflow's job instead. So:

- New `check_bazel_modules.yml`: a small standalone workflow, triggered directly on `pull_request`, that calls the same `_check_bazel_modules.yml` reusable workflow.
- `post_module_diff_comment.yml`'s `workflow_run` target changes from `"ci"` to `"check_bazel_modules"`.
- `ci.yaml`'s own `bazel_modules` job is untouched -- it still gates `distribution_compiles` exactly as before.

**Tradeoff**: the modules check now runs twice per PR (once standalone for the fast comment, once inside `ci` for the gate). It's a cheap job -- checkout + a few `bazel run` calls over the Python tooling, no distribution build -- so this is a small, deliberate cost accepted in exchange for the comment posting independently of how long the rest of CI takes.

## Verification

- Both new/changed YAML files parse cleanly (`yaml.safe_load`).
- Confirmed via `grep` that `post_module_diff_comment.yml` is the only `workflow_run` listener in the repo, so no other consumer needed updating.
- Mirrors the existing `_check_bazel_modules.yml` invocation pattern already used identically in `ci.yaml` (`uses: ./.github/workflows/_check_bazel_modules.yml` + `secrets: inherit`), so behavior of the check itself is unchanged -- only its trigger/timing.
- Not able to test the actual `workflow_run` firing/comment-posting locally (inherent to this kind of change); will need to be observed on this PR's own first CI run once opened.

## Acknowledgements

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Code of Conduct](../CODE_OF_CONDUCT.md) and agree to abide by it.
- [x] I have read and complied with the [OSRF Policy on the Use of Generative AI Tools ("Generative AI") in Contributions](https://github.com/openrobotics/osra-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md).

## Generative AI disclosure

- Was any generative AI tool used in this contribution? Yes.
- If yes, which tool(s), and for which part(s) of the contribution? Claude Code (Sonnet 5) diagnosed the root cause (workflow_run's whole-workflow-completion semantics vs. GitHub Actions' lack of cross-workflow job dependencies) and authored this change, under my direction and review.

## Related issue(s)

- Fixes: N/A -- no tracked issue; noticed while waiting on PR #149's module-diff comment.

## Additional information

Packages affected: none (`.github/workflows/` only).