### PR TITLE
fix: resolve the module-diff comment's target PR by head branch, not commit search

### DIFF
--- a/.github/workflows/post_module_diff_comment.yml
+++ b/.github/workflows/post_module_diff_comment.yml
@@ -73,13 +73,22 @@ jobs:
 
           // workflow_run's own `pull_requests` field is empty for
           // fork-originated PRs, so resolve the PR from the run's head
-          // commit instead, which works regardless of fork status.
-          const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+          // repo/branch instead (both always populated, fork or not).
+          // An earlier version of this used
+          // repos.listPullRequestsAssociatedWithCommit(commit_sha) --
+          // that endpoint is backed by a search index that's frequently
+          // stale for a commit just force-pushed to a fork branch (seen
+          // in practice: still empty several minutes later), silently
+          // dropping the comment via the `if (!pr) return` below.
+          // Querying by head branch instead hits the PR list directly,
+          // not a search index, so it's immediately consistent.
+          const { data: prs } = await github.rest.pulls.list({
             owner: context.repo.owner,
             repo: context.repo.repo,
-            commit_sha: context.payload.workflow_run.head_sha,
+            head: `${context.payload.workflow_run.head_repository.owner.login}:${context.payload.workflow_run.head_branch}`,
+            state: 'open',
           });
-          const pr = prs.find((p) => p.state === 'open');
+          const pr = prs[0];
           if (!pr) return;
 
           const { data: comments } = await github.rest.issues.listComments({


### PR DESCRIPTION
## Summary

Follow-up to #159: after that merged, `check_bazel_modules` correctly fired for PR #149, uploaded the diff artifacts, and `post_module_diff_comment` correctly triggered via `workflow_run` -- but no comment ever showed up, silently.

Root cause: the script resolves which PR to comment on via `repos.listPullRequestsAssociatedWithCommit(head_sha)` (`GET /repos/{owner}/{repo}/commits/{sha}/pulls`), which the existing comment explains is needed because `workflow_run`'s own `pull_requests` field is empty for fork-originated PRs. That endpoint turns out to be backed by a search index that's frequently stale for a commit just force-pushed to a fork branch -- verified live: it returned an empty array for PR #149's actual, current, open head commit, several minutes after the triggering run completed. The script hits `if (!pr) return` in that case and exits cleanly with no error anywhere in the logs, which is exactly why this was silent and easy to miss.

Fix: resolve the PR by head repo/branch instead (`pulls.list` with a `head: owner:branch` filter). Both `head_repository` and `head_branch` are always populated in the `workflow_run` payload regardless of fork status (unlike `pull_requests`), and this hits the PR list directly rather than a possibly-stale search index.

## Verification

- `gh api repos/.../commits/<PR149's actual head sha>/pulls` returns `[]` (confirming the bug, reproduced against the real repo).
- `gh api "repos/.../pulls?head=asymingt:asymingt/implement-ouster-ros&state=open"` returns PR #149 immediately (confirming the fix's approach works).
- YAML parses cleanly (`yaml.safe_load`).
- Not able to fully test the `workflow_run` firing end-to-end locally (inherent to this kind of change); will confirm once this lands by checking PR #149 gets its comment on the next push, or by re-running `check_bazel_modules` there.

## Acknowledgements

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Code of Conduct](../CODE_OF_CONDUCT.md) and agree to abide by it.
- [x] I have read and complied with the [OSRF Policy on the Use of Generative AI Tools ("Generative AI") in Contributions](https://github.com/openrobotics/osra-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md).

## Generative AI disclosure

- Was any generative AI tool used in this contribution? Yes.
- If yes, which tool(s), and for which part(s) of the contribution? Claude Code (Sonnet 5) diagnosed this by inspecting live Actions run logs and directly reproducing the stale-search-index behavior against the GitHub API, then authored the fix, under my direction and review.

## Related issue(s)

- Fixes: N/A -- no tracked issue; found while debugging why #159 didn't make PR #149's comment appear.

## Additional information

Packages affected: none (`.github/workflows/` only). Direct follow-up to #159.