### PR TITLE
bugfix: enable workspace trust to enable gemini to perform tasks

### DIFF
--- a/.github/workflows/gemini_implement_issue.yml
+++ b/.github/workflows/gemini_implement_issue.yml
@@ -152,3 +152,4 @@ jobs:
             thing.
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GEMINI_CLI_TRUST_WORKSPACE: "true"

--- a/.github/workflows/gemini_support.yml
+++ b/.github/workflows/gemini_support.yml
@@ -114,3 +114,4 @@ jobs:
           helpfully and push any necessary commits.
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GEMINI_CLI_TRUST_WORKSPACE: "true"


### PR DESCRIPTION
## Summary

Add `GEMINI_CLI_TRUST_WORKSPACE: "true"` to workflows to enable Gemini to action requests.

## Acknowledgements

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Code of Conduct](../CODE_OF_CONDUCT.md) and agree to abide by it.
- [x] I have read and complied with the [OSRF Policy on the Use of Generative AI Tools ("Generative AI") in Contributions](https://github.com/openrobotics/osra-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md).

## Generative AI disclosure

<!--
Per the OSRF Generative AI policy linked above, disclose whether -- and how
-- generative/AI tools were used anywhere in this contribution (e.g. code,
tests, commit messages, this PR description).
-->

- Was any generative AI tool used in this contribution? No
- If yes, which tool(s), and for which part(s) of the contribution?

## Related issue(s)

<!--
Does this PR fix a known, reported issue? Link it (e.g. "Fixes #123") so it
closes automatically on merge. If there's no tracked issue, say so.
-->

- Fixes:

## Additional information

<!-- Anything else reviewers should know: testing performed, follow-up work, open questions, etc. -->
