### PR TITLE
fix: switch to @gemini-bot and polish prompt

### DIFF
--- a/.github/workflows/gemini_implement_issue.yml
+++ b/.github/workflows/gemini_implement_issue.yml
@@ -178,18 +178,44 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         BRANCH_NAME: ${{ steps.branch.outputs.branch_name }}
       run: |
-        # 1. Format Bazel files
-        buildifier -mode fix -r . || true
+        # 1. Compute diff status for modified/added files
+        {
+          git diff --name-status origin/main 2>/dev/null || true
+          git status --porcelain | grep '^??' | awk '{print "A\t" $2}' || true
+        } > /tmp/diff_status.txt
 
-        # 2. Recompute source.json integrity hashes for all module versions
+        # 2. Format and regenerate hashes only for changed module versions and Bazel files
         python3 -c "
+        import subprocess
         from pathlib import Path
         from tools.ci import bzlmod_lib
-        for base in [Path('modules'), Path('bcr_staging/modules')]:
-            if base.exists():
-                for p in base.glob('*/*'):
-                    if p.is_dir() and (p / 'source.json').exists() and p.name != '0.0.0':
-                        bzlmod_lib.regenerate_integrity_hashes(p)
+
+        diff_file = Path('/tmp/diff_status.txt')
+        if diff_file.exists():
+            diffs = bzlmod_lib.parse_diff_status_file(diff_file)
+            version_dirs = set()
+            bazel_files = set()
+            for status, file_path in diffs:
+                p = Path(file_path)
+                if p.suffix in ('.bazel', '.bzl') or p.name in ('BUILD', 'BUILD.bazel', 'MODULE.bazel', 'WORKSPACE', 'WORKSPACE.bazel'):
+                    if p.is_file():
+                        bazel_files.add(p)
+                for prefix in ('modules/', 'bcr_staging/modules/'):
+                    if file_path.startswith(prefix):
+                        parts = file_path[len(prefix):].split('/')
+                        if len(parts) >= 2 and parts[1] != 'metadata.json':
+                            vdir = Path(prefix) / parts[0] / parts[1]
+                            if vdir.is_dir() and (vdir / 'source.json').exists() and parts[1] != '0.0.0':
+                                version_dirs.add(vdir)
+
+            for vdir in version_dirs:
+                bazel_files.update(f for f in vdir.rglob('*') if f.is_file() and (f.suffix in ('.bazel', '.bzl') or f.name in ('BUILD.bazel', 'MODULE.bazel')))
+
+            if bazel_files:
+                subprocess.run(['buildifier', '-mode', 'fix'] + [str(f) for f in sorted(bazel_files)])
+
+            for vdir in sorted(version_dirs):
+                bzlmod_lib.regenerate_integrity_hashes(vdir)
         "
 
         # 3. Commit and push any formatting / hash updates
@@ -199,22 +225,6 @@ jobs:
           git add -A
           git commit -s -m "chore: format bazel files and regenerate source.json hashes" || true
           git push origin "$BRANCH_NAME" || true
-        fi
-
-        # 4. If branch has commits relative to origin/main, ensure a PR exists
-        if git rev-parse --verify "$BRANCH_NAME" >/dev/null 2>&1; then
-          COMMITS=$(git log origin/main.."$BRANCH_NAME" --oneline || true)
-          if [ -n "$COMMITS" ]; then
-            git push origin "$BRANCH_NAME" || true
-            PR_EXISTS=$(gh pr list --head "$BRANCH_NAME" --json number -q '.[0].number' || true)
-            if [ -z "$PR_EXISTS" ]; then
-              gh pr create \
-                --head "$BRANCH_NAME" \
-                --base main \
-                --title "feat: implement issue #${{ github.event.issue.number }} (${{ github.event.issue.title }})" \
-                --body "Fixes #${{ github.event.issue.number }}" || true
-            fi
-          fi
         fi
 
     - name: Post response to issue

--- a/.github/workflows/gemini_implement_issue.yml
+++ b/.github/workflows/gemini_implement_issue.yml
@@ -62,6 +62,12 @@ jobs:
         disk-cache: false
         repository-cache: true
 
+    - name: Setup buildifier
+      run: |
+        curl -L https://github.com/bazelbuild/buildtools/releases/download/v8.5.1/buildifier-linux-amd64 -o buildifier
+        chmod +x buildifier
+        sudo mv buildifier /usr/local/bin/buildifier
+
     - name: Setup git identity
       run: |
         git config --global user.email "gemini-bot@users.noreply.github.com"
@@ -124,6 +130,10 @@ jobs:
             AGENTS.md) before committing. Do not attempt a full distribution
             build; .github/workflows/ci.yaml already does that comprehensively
             on the PR.
+          - Never manually calculate sha256 or hand-edit source.json. If you
+            modify any files in overlay/ or run buildifier, always recompute
+            source.json integrity hashes using create_patch or
+            tools.ci.bzlmod_lib.regenerate_integrity_hashes.
           - Sign off every commit (`git commit -s`) per the DCO requirement in
             CONTRIBUTING.md, using the gemini[bot] identity already configured
             in this job.
@@ -161,6 +171,51 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GEMINI_CLI_TRUST_WORKSPACE: "true"
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Ensure format and regenerate source.json integrity hashes
+      if: always()
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        BRANCH_NAME: ${{ steps.branch.outputs.branch_name }}
+      run: |
+        # 1. Format Bazel files
+        buildifier -mode fix -r . || true
+
+        # 2. Recompute source.json integrity hashes for all module versions
+        python3 -c "
+        from pathlib import Path
+        from tools.ci import bzlmod_lib
+        for base in [Path('modules'), Path('bcr_staging/modules')]:
+            if base.exists():
+                for p in base.glob('*/*'):
+                    if p.is_dir() and (p / 'source.json').exists() and p.name != '0.0.0':
+                        bzlmod_lib.regenerate_integrity_hashes(p)
+        "
+
+        # 3. Commit and push any formatting / hash updates
+        if [ -n "$(git status --porcelain)" ]; then
+          git config --global user.email "gemini-bot@users.noreply.github.com"
+          git config --global user.name "gemini[bot]"
+          git add -A
+          git commit -s -m "chore: format bazel files and regenerate source.json hashes" || true
+          git push origin "$BRANCH_NAME" || true
+        fi
+
+        # 4. If branch has commits relative to origin/main, ensure a PR exists
+        if git rev-parse --verify "$BRANCH_NAME" >/dev/null 2>&1; then
+          COMMITS=$(git log origin/main.."$BRANCH_NAME" --oneline || true)
+          if [ -n "$COMMITS" ]; then
+            git push origin "$BRANCH_NAME" || true
+            PR_EXISTS=$(gh pr list --head "$BRANCH_NAME" --json number -q '.[0].number' || true)
+            if [ -z "$PR_EXISTS" ]; then
+              gh pr create \
+                --head "$BRANCH_NAME" \
+                --base main \
+                --title "feat: implement issue #${{ github.event.issue.number }} (${{ github.event.issue.title }})" \
+                --body "Fixes #${{ github.event.issue.number }}" || true
+            fi
+          fi
+        fi
 
     - name: Post response to issue
       if: steps.gemini.outputs.summary != ''

--- a/.github/workflows/gemini_implement_issue.yml
+++ b/.github/workflows/gemini_implement_issue.yml
@@ -125,15 +125,16 @@ jobs:
             edits discards them, see AGENTS.md) and means a partial,
             genuinely useful PR exists even if you run out of turns before
             finishing everything.
-          - Run the relevant fast local checks (buildifier, ruff, and any
-            targeted test for what you touched — see the Linting section of
-            AGENTS.md) before committing. Do not attempt a full distribution
-            build; .github/workflows/ci.yaml already does that comprehensively
-            on the PR.
-          - Never manually calculate sha256 or hand-edit source.json. If you
-            modify any files in overlay/ or run buildifier, always recompute
-            source.json integrity hashes using create_patch or
-            tools.ci.bzlmod_lib.regenerate_integrity_hashes.
+          - Do not attempt a full distribution build; The github workflow 
+            .github/workflows/ci.yaml already does that comprehensively
+            on any commit made to a PR that changes behavior.
+          - It is critical that before calling create_patch you first run the
+            relevant fast local checks (buildifier, ruff, and any targeted test
+            for what you touched — see the Linting section of AGENTS.md) on the
+            vendored bazel module. After runnign create_patch do not edit any
+            Bazel modules in ./modules or ./bcr_staging. If you want to fix
+            anything, you must do this in the vendored folder and then re-run
+            the linting, and testing before calling create_patch again.
           - Sign off every commit (`git commit -s`) per the DCO requirement in
             CONTRIBUTING.md, using the gemini[bot] identity already configured
             in this job.
@@ -171,61 +172,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GEMINI_CLI_TRUST_WORKSPACE: "true"
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Ensure format and regenerate source.json integrity hashes
-      if: always()
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        BRANCH_NAME: ${{ steps.branch.outputs.branch_name }}
-      run: |
-        # 1. Compute diff status for modified/added files
-        {
-          git diff --name-status origin/main 2>/dev/null || true
-          git status --porcelain | grep '^??' | awk '{print "A\t" $2}' || true
-        } > /tmp/diff_status.txt
-
-        # 2. Format and regenerate hashes only for changed module versions and Bazel files
-        python3 -c "
-        import subprocess
-        from pathlib import Path
-        from tools.ci import bzlmod_lib
-
-        diff_file = Path('/tmp/diff_status.txt')
-        if diff_file.exists():
-            diffs = bzlmod_lib.parse_diff_status_file(diff_file)
-            version_dirs = set()
-            bazel_files = set()
-            for status, file_path in diffs:
-                p = Path(file_path)
-                if p.suffix in ('.bazel', '.bzl') or p.name in ('BUILD', 'BUILD.bazel', 'MODULE.bazel', 'WORKSPACE', 'WORKSPACE.bazel'):
-                    if p.is_file():
-                        bazel_files.add(p)
-                for prefix in ('modules/', 'bcr_staging/modules/'):
-                    if file_path.startswith(prefix):
-                        parts = file_path[len(prefix):].split('/')
-                        if len(parts) >= 2 and parts[1] != 'metadata.json':
-                            vdir = Path(prefix) / parts[0] / parts[1]
-                            if vdir.is_dir() and (vdir / 'source.json').exists() and parts[1] != '0.0.0':
-                                version_dirs.add(vdir)
-
-            for vdir in version_dirs:
-                bazel_files.update(f for f in vdir.rglob('*') if f.is_file() and (f.suffix in ('.bazel', '.bzl') or f.name in ('BUILD.bazel', 'MODULE.bazel')))
-
-            if bazel_files:
-                subprocess.run(['buildifier', '-mode', 'fix'] + [str(f) for f in sorted(bazel_files)])
-
-            for vdir in sorted(version_dirs):
-                bzlmod_lib.regenerate_integrity_hashes(vdir)
-        "
-
-        # 3. Commit and push any formatting / hash updates
-        if [ -n "$(git status --porcelain)" ]; then
-          git config --global user.email "gemini-bot@users.noreply.github.com"
-          git config --global user.name "gemini[bot]"
-          git add -A
-          git commit -s -m "chore: format bazel files and regenerate source.json hashes" || true
-          git push origin "$BRANCH_NAME" || true
-        fi
 
     - name: Post response to issue
       if: steps.gemini.outputs.summary != ''

--- a/.github/workflows/gemini_support.yml
+++ b/.github/workflows/gemini_support.yml
@@ -70,6 +70,12 @@ jobs:
         disk-cache: false
         repository-cache: true
 
+    - name: Setup buildifier
+      run: |
+        curl -L https://github.com/bazelbuild/buildtools/releases/download/v8.5.1/buildifier-linux-amd64 -o buildifier
+        chmod +x buildifier
+        sudo mv buildifier /usr/local/bin/buildifier
+
     - name: Setup git identity
       run: |
         git config --global user.email "gemini-bot@users.noreply.github.com"
@@ -99,6 +105,9 @@ jobs:
           command and read its own error messages instead. Checkpoint real progress via
           create-patch at natural milestones as you go, not only at the end, since
           re-vendoring a package with uncommitted edits discards them (see AGENTS.md).
+          Never manually calculate sha256 or hand-edit source.json. If you modify any
+          files in overlay/ or run buildifier, always recompute source.json integrity
+          hashes using create_patch or tools.ci.bzlmod_lib.regenerate_integrity_hashes.
           Sign off every commit with git commit -s per the DCO requirement in
           CONTRIBUTING.md, using the gemini[bot] identity. If you open or update a pull
           request, use .github/PULL_REQUEST_TEMPLATE.md and fill out every section
@@ -116,6 +125,34 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GEMINI_CLI_TRUST_WORKSPACE: "true"
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Ensure format and regenerate source.json integrity hashes
+      if: always()
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        # 1. Format Bazel files
+        buildifier -mode fix -r . || true
+
+        # 2. Recompute source.json integrity hashes for all module versions
+        python3 -c "
+        from pathlib import Path
+        from tools.ci import bzlmod_lib
+        for base in [Path('modules'), Path('bcr_staging/modules')]:
+            if base.exists():
+                for p in base.glob('*/*'):
+                    if p.is_dir() and (p / 'source.json').exists() and p.name != '0.0.0':
+                        bzlmod_lib.regenerate_integrity_hashes(p)
+        "
+
+        # 3. Commit and push any formatting / hash updates if changes are present
+        if [ -n "$(git status --porcelain)" ]; then
+          git config --global user.email "gemini-bot@users.noreply.github.com"
+          git config --global user.name "gemini[bot]"
+          git add -A
+          git commit -s -m "chore: format bazel files and regenerate source.json hashes" || true
+          git push origin HEAD || true
+        fi
 
     - name: Post response to issue/PR
       if: steps.gemini.outputs.summary != ''

--- a/.github/workflows/gemini_support.yml
+++ b/.github/workflows/gemini_support.yml
@@ -12,17 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Interactive companion to gemini_implement_issue.yml. Mention "@gemini" in an
+# Interactive companion to gemini_implement_issue.yml. Mention "@gemini-bot" in an
 # issue, a PR comment, or a PR review (including on PRs Gemini itself opened)
 # and it responds or pushes follow-up commits addressing the feedback. Like
 # the auto-implement workflow, the action only acts for users with write
-# access to the repo, so only a maintainer's "@gemini" mention triggers it —
+# access to the repo, so only a maintainer's "@gemini-bot" mention triggers it —
 # but the surrounding comment/issue thread is still untrusted content from
 # whoever wrote it, so skim before relying on Gemini's response.
 
 name: gemini-interactive
 
-run-name: Respond to @gemini mention
+run-name: Respond to @gemini-bot mention
 
 on:
   issue_comment:
@@ -47,13 +47,13 @@ permissions:
 
 jobs:
   gemini:
-    name: Respond to @gemini
+    name: Respond to @gemini-bot
     if: |
       (
-        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@gemini') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
-        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@gemini') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
-        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@gemini') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)) ||
-        (github.event_name == 'issues' && (contains(github.event.issue.body, '@gemini') || contains(github.event.issue.title, '@gemini')) && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association))
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@gemini-bot') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@gemini-bot') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@gemini-bot') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@gemini-bot') || contains(github.event.issue.title, '@gemini-bot')) && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association))
       )
     runs-on: ubuntu-latest
 

--- a/.github/workflows/gemini_support.yml
+++ b/.github/workflows/gemini_support.yml
@@ -61,7 +61,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v7
       with:
-        fetch-depth: 1
+        fetch-depth: 0
 
     - name: Setup Bazel
       uses: bazel-contrib/setup-bazel@0.19.0
@@ -131,18 +131,44 @@ jobs:
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        # 1. Format Bazel files
-        buildifier -mode fix -r . || true
+        # 1. Compute diff status for modified/added files
+        {
+          git diff --name-status origin/main 2>/dev/null || git diff --name-status HEAD~1 2>/dev/null || true
+          git status --porcelain | grep '^??' | awk '{print "A\t" $2}' || true
+        } > /tmp/diff_status.txt
 
-        # 2. Recompute source.json integrity hashes for all module versions
+        # 2. Format and regenerate hashes only for changed module versions and Bazel files
         python3 -c "
+        import subprocess
         from pathlib import Path
         from tools.ci import bzlmod_lib
-        for base in [Path('modules'), Path('bcr_staging/modules')]:
-            if base.exists():
-                for p in base.glob('*/*'):
-                    if p.is_dir() and (p / 'source.json').exists() and p.name != '0.0.0':
-                        bzlmod_lib.regenerate_integrity_hashes(p)
+
+        diff_file = Path('/tmp/diff_status.txt')
+        if diff_file.exists():
+            diffs = bzlmod_lib.parse_diff_status_file(diff_file)
+            version_dirs = set()
+            bazel_files = set()
+            for status, file_path in diffs:
+                p = Path(file_path)
+                if p.suffix in ('.bazel', '.bzl') or p.name in ('BUILD', 'BUILD.bazel', 'MODULE.bazel', 'WORKSPACE', 'WORKSPACE.bazel'):
+                    if p.is_file():
+                        bazel_files.add(p)
+                for prefix in ('modules/', 'bcr_staging/modules/'):
+                    if file_path.startswith(prefix):
+                        parts = file_path[len(prefix):].split('/')
+                        if len(parts) >= 2 and parts[1] != 'metadata.json':
+                            vdir = Path(prefix) / parts[0] / parts[1]
+                            if vdir.is_dir() and (vdir / 'source.json').exists() and parts[1] != '0.0.0':
+                                version_dirs.add(vdir)
+
+            for vdir in version_dirs:
+                bazel_files.update(f for f in vdir.rglob('*') if f.is_file() and (f.suffix in ('.bazel', '.bzl') or f.name in ('BUILD.bazel', 'MODULE.bazel')))
+
+            if bazel_files:
+                subprocess.run(['buildifier', '-mode', 'fix'] + [str(f) for f in sorted(bazel_files)])
+
+            for vdir in sorted(version_dirs):
+                bzlmod_lib.regenerate_integrity_hashes(vdir)
         "
 
         # 3. Commit and push any formatting / hash updates if changes are present

--- a/.github/workflows/gemini_support.yml
+++ b/.github/workflows/gemini_support.yml
@@ -93,92 +93,83 @@ jobs:
           ACTOR: ${{ github.actor }}
           COMMENT BODY: ${{ github.event.comment.body || github.event.review.body || github.event.issue.body }}
           PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          
+          First, read AGENTS.md at the repo root in full — it's the mandatory
+          guidance for coding agents in this repository, including the
+          setup-workspace / vendor-module / create-patch skill pipeline in
+          .agent/skills/ for patching packages under modules/, plus linting,
+          licensing, and testing conventions. Follow it exactly, and use
+          those skills rather than hand-editing anything under modules/ or
+          hand-rolling `bazel run //tools/ci:...` invocations yourself.
 
-          Read AGENTS.md at the repo root and follow it exactly, including using the
-          setup-workspace/vendor-module/create-patch skills in .agent/skills/ to patch
-          anything under modules/ (never hand-edit files under modules/<pkg>/<version>/,
-          never modify or delete an existing version directory). Work efficiently: before
-          writing new Bazel content, find an existing, already-implemented package with
-          a similar shape and mirror its structure rather than inventing one from scratch,
-          and don't spend turns hand-exploring the runner environment or hand-rolling
-          registry checks (e.g. curl against bcr.bazel.build) -- attempt the real bazel
-          command and read its own error messages instead. Checkpoint real progress via
-          create-patch at natural milestones as you go, not only at the end, since
-          re-vendoring a package with uncommitted edits discards them (see AGENTS.md).
-          Never manually calculate sha256 or hand-edit source.json. If you modify any
-          files in overlay/ or run buildifier, always recompute source.json integrity
-          hashes using create_patch or tools.ci.bzlmod_lib.regenerate_integrity_hashes.
-          Sign off every commit with git commit -s per the DCO requirement in
-          CONTRIBUTING.md, using the gemini[bot] identity. If you open or update a pull
-          request, use .github/PULL_REQUEST_TEMPLATE.md and fill out every section
-          honestly. Keep the PR description concise and respectful of reviewers'
-          time: avoid over-the-top enthusiasm, em dashes, emojis, or excessive background
-          information. Include a truthful Generative AI disclosure per the OSRF policy
-          it links (identifying as Gemini). Never merge, approve, or request review on
-          a pull request yourself. If a request turns out to be too large for one PR
-          (e.g. porting a bundled third-party SDK, or a dependency missing from the
-          Bazel Central Registry entirely), don't brute-force it to completion - say so,
-          explain the real scope, and propose splitting it into smaller pieces instead
-          of running out of turns mid-attempt. Respond to the user's feedback or request
-          helpfully and push any necessary commits.
+          Then taken any action that is required to discuss the issue or update a
+          pull request, and then respond with a comment. Be careful to follow
+          these specific instructions as you carry out your work:
+
+          - Work efficiently: before writing any new Bazel content, find an
+            existing, already-implemented package in modules/ with a similar
+            shape (e.g. another message-only package, another driver with
+            ROS2 components) and mirror its exact structure rather than
+            inventing one from scratch — this is far faster and more likely
+            to be correct than guessing. Don't spend turns hand-exploring the
+            runner environment (system paths, global config files) or
+            hand-rolling registry checks (e.g. curl against bcr.bazel.build)
+            to verify a dependency exists — just attempt the real
+            bazel build/create-patch command and read Bazel's own error
+            messages, which are authoritative and faster than guessing.
+          - Checkpoint real progress via the create-patch skill at natural
+            milestones as you go, not only at the very end — this protects
+            against losing work (re-vendoring a package with uncommitted
+            edits discards them, see AGENTS.md) and means a partial,
+            genuinely useful PR exists even if you run out of turns before
+            finishing everything.
+          - Do not attempt a full distribution build; The github workflow 
+            .github/workflows/ci.yaml already does that comprehensively
+            on any commit made to a PR that changes behavior.
+          - It is critical that before calling create_patch you first run the
+            relevant fast local checks (buildifier, ruff, and any targeted test
+            for what you touched — see the Linting section of AGENTS.md) on the
+            vendored bazel module. After runnign create_patch do not edit any
+            Bazel modules in ./modules or ./bcr_staging. If you want to fix
+            anything, you must do this in the vendored folder and then re-run
+            the linting, and testing before calling create_patch again.
+          - Sign off every commit (`git commit -s`) per the DCO requirement in
+            CONTRIBUTING.md, using the gemini[bot] identity already configured
+            in this job.
+          - Push the branch, then open the PR against main with `gh pr create`.
+            Use .github/PULL_REQUEST_TEMPLATE.md as the PR body verbatim,
+            filling out every section honestly. Keep the PR description concise
+            and respectful of reviewers' time: avoid over-the-top enthusiasm,
+            em dashes, emojis, or excessive background information. In
+            particular, answer the Generative AI disclosure truthfully (you are
+            Gemini; say so and describe what you did) per the OSRF Generative AI
+            policy it links, and put "Fixes #${{ github.event.issue.number }}"
+            under Related issue(s). Title the PR clearly, and leave it open for
+            @${{ github.repository_owner }} to review - do not merge it,
+            approve it, or request review from anyone yourself.
+          - If the issue is too vague or under-specified to implement safely,
+            do not guess or implement something speculative: instead run
+            `gh issue comment` explaining what clarification you need, and do
+            not open a PR.
+          - If the issue is well-specified but genuinely too large for one PR
+            (e.g. it would require porting a bundled third-party SDK spanning
+            tens of thousands of lines, or authoring a brand-new Bazel module
+            from scratch for a dependency that doesn't exist in the Bazel
+            Central Registry at all), don't try to brute-force a complete
+            implementation — you will run out of turns before finishing and
+            waste the run. Instead, do enough investigation to describe the
+            real scope (what's actually needed vs. what looked scary at
+            first glance — see AGENTS.md's guidance on checking the
+            consuming package's build options before assuming a bundled
+            dependency is required), then `gh issue comment` proposing how to
+            split it into smaller, independently-mergeable issues, and open
+            a PR only for whatever well-scoped first slice you did manage to
+            finish (if any) rather than an incomplete attempt at the whole
+            thing.
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GEMINI_CLI_TRUST_WORKSPACE: "true"
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Ensure format and regenerate source.json integrity hashes
-      if: always()
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        # 1. Compute diff status for modified/added files
-        {
-          git diff --name-status origin/main 2>/dev/null || git diff --name-status HEAD~1 2>/dev/null || true
-          git status --porcelain | grep '^??' | awk '{print "A\t" $2}' || true
-        } > /tmp/diff_status.txt
-
-        # 2. Format and regenerate hashes only for changed module versions and Bazel files
-        python3 -c "
-        import subprocess
-        from pathlib import Path
-        from tools.ci import bzlmod_lib
-
-        diff_file = Path('/tmp/diff_status.txt')
-        if diff_file.exists():
-            diffs = bzlmod_lib.parse_diff_status_file(diff_file)
-            version_dirs = set()
-            bazel_files = set()
-            for status, file_path in diffs:
-                p = Path(file_path)
-                if p.suffix in ('.bazel', '.bzl') or p.name in ('BUILD', 'BUILD.bazel', 'MODULE.bazel', 'WORKSPACE', 'WORKSPACE.bazel'):
-                    if p.is_file():
-                        bazel_files.add(p)
-                for prefix in ('modules/', 'bcr_staging/modules/'):
-                    if file_path.startswith(prefix):
-                        parts = file_path[len(prefix):].split('/')
-                        if len(parts) >= 2 and parts[1] != 'metadata.json':
-                            vdir = Path(prefix) / parts[0] / parts[1]
-                            if vdir.is_dir() and (vdir / 'source.json').exists() and parts[1] != '0.0.0':
-                                version_dirs.add(vdir)
-
-            for vdir in version_dirs:
-                bazel_files.update(f for f in vdir.rglob('*') if f.is_file() and (f.suffix in ('.bazel', '.bzl') or f.name in ('BUILD.bazel', 'MODULE.bazel')))
-
-            if bazel_files:
-                subprocess.run(['buildifier', '-mode', 'fix'] + [str(f) for f in sorted(bazel_files)])
-
-            for vdir in sorted(version_dirs):
-                bzlmod_lib.regenerate_integrity_hashes(vdir)
-        "
-
-        # 3. Commit and push any formatting / hash updates if changes are present
-        if [ -n "$(git status --porcelain)" ]; then
-          git config --global user.email "gemini-bot@users.noreply.github.com"
-          git config --global user.name "gemini[bot]"
-          git add -A
-          git commit -s -m "chore: format bazel files and regenerate source.json hashes" || true
-          git push origin HEAD || true
-        fi
 
     - name: Post response to issue/PR
       if: steps.gemini.outputs.summary != ''

--- a/README.md
+++ b/README.md
@@ -337,8 +337,8 @@ Repository maintainers can use two automated GitHub Actions workflows powered by
    - Add the `gemini-implement` label to an issue.
    - The workflow creates an implementation branch, applies changes following the repository skills in `.agent/skills/`, and opens a pull request for review.
 
-2. **Interactive assistance (`@gemini` mention)**
-   - Mention `@gemini` in an issue, pull request comment, or pull request review.
+2. **Interactive assistance (`@gemini-bot` mention)**
+   - Mention `@gemini-bot` in an issue, pull request comment, or pull request review.
    - The workflow responds to questions, investigates build/test failures, or pushes follow-up commits to address review feedback.
 
 *Note: Execution is restricted to repository maintainers (`OWNER`, `MEMBER`, or `COLLABORATOR`) and requires the `GEMINI_API_KEY` repository secret.*

--- a/tools/ci/check_pr_modules.py
+++ b/tools/ci/check_pr_modules.py
@@ -20,7 +20,90 @@ import re
 import sys
 from pathlib import Path
 
-from tools.ci.bzlmod_lib import increment_version, parse_diff_status_file
+from tools.ci.bzlmod_lib import calculate_integrity_hash_for_file, increment_version, parse_diff_status_file
+
+def check_source_json_integrity(version_dir: Path, rel_version_path: str) -> list[str]:
+    violations = []
+    source_json_path = version_dir / "source.json"
+    if not source_json_path.exists():
+        if (version_dir / "overlay").exists() or (version_dir / "patches").exists():
+            violations.append(f"Missing source.json in {rel_version_path}")
+        return violations
+
+    try:
+        with open(source_json_path, "r") as f:
+            source = json.load(f)
+    except Exception as e:
+        violations.append(f"Failed to parse JSON in {rel_version_path}/source.json: {e}")
+        return violations
+
+    if not isinstance(source, dict):
+        violations.append(f"{rel_version_path}/source.json must be a JSON object")
+        return violations
+
+    # Check overlay hashes
+    overlay_dir = version_dir / "overlay"
+    expected_overlays = source.get("overlay", {})
+    if not isinstance(expected_overlays, dict):
+        violations.append(f"{rel_version_path}/source.json 'overlay' field must be a dictionary")
+        expected_overlays = {}
+
+    actual_overlays = {}
+    if overlay_dir.exists():
+        for f in overlay_dir.rglob("*"):
+            if f.is_file() and f.name != "MODULE.bazel.lock":
+                rel = f.relative_to(overlay_dir).as_posix()
+                actual_overlays[rel] = calculate_integrity_hash_for_file(f)
+
+    for rel_path, actual_hash in actual_overlays.items():
+        if rel_path not in expected_overlays:
+            violations.append(
+                f"File '{rel_path}' exists in {rel_version_path}/overlay but is missing from source.json overlay list"
+            )
+        elif expected_overlays[rel_path] != actual_hash:
+            violations.append(
+                f"Integrity mismatch for overlay '{rel_path}' in {rel_version_path}/source.json: "
+                f"expected {expected_overlays[rel_path]}, but actual file hash is {actual_hash}"
+            )
+
+    for rel_path in expected_overlays:
+        if rel_path not in actual_overlays:
+            violations.append(
+                f"Overlay file '{rel_path}' declared in {rel_version_path}/source.json does not exist on disk"
+            )
+
+    # Check patches hashes
+    patches_dir = version_dir / "patches"
+    expected_patches = source.get("patches", {})
+    if not isinstance(expected_patches, dict):
+        violations.append(f"{rel_version_path}/source.json 'patches' field must be a dictionary")
+        expected_patches = {}
+
+    actual_patches = {}
+    if patches_dir.exists():
+        for f in patches_dir.rglob("*"):
+            if f.is_file():
+                rel = f.relative_to(patches_dir).as_posix()
+                actual_patches[rel] = calculate_integrity_hash_for_file(f)
+
+    for rel_path, actual_hash in actual_patches.items():
+        if rel_path not in expected_patches:
+            violations.append(
+                f"File '{rel_path}' exists in {rel_version_path}/patches but is missing from source.json patches list"
+            )
+        elif expected_patches[rel_path] != actual_hash:
+            violations.append(
+                f"Integrity mismatch for patch '{rel_path}' in {rel_version_path}/source.json: "
+                f"expected {expected_patches[rel_path]}, but actual file hash is {actual_hash}"
+            )
+
+    for rel_path in expected_patches:
+        if rel_path not in actual_patches:
+            violations.append(
+                f"Patch file '{rel_path}' declared in {rel_version_path}/source.json does not exist on disk"
+            )
+
+    return violations
 
 def check_metadata_json(file_path: str, old_metadata_dir: Path, working_dir: Path) -> list[str]:
     violations = []
@@ -159,11 +242,19 @@ def check_violations(diffs: list[tuple[str, str]], old_metadata_dir: Path, worki
     # Ensure target_dir has a trailing slash for prefix matching (e.g. "modules/" or "bcr_staging/modules/")
     prefix = target_dir.strip("/") + "/"
     target_parts = Path(prefix).parts
+    affected_versions = set()
 
     for status, file_path in diffs:
         # We only care about files under target_dir
         if not file_path.startswith(prefix):
             continue
+
+        path_parts = Path(file_path).parts
+        if len(path_parts) >= len(target_parts) + 2:
+            pkg = path_parts[len(target_parts)]
+            ver = path_parts[len(target_parts) + 1]
+            if ver != "metadata.json":
+                affected_versions.add((pkg, ver))
 
         # Rule 1: A PR cannot delete any files under target_dir
         if status.startswith("D"):
@@ -200,6 +291,12 @@ def check_violations(diffs: list[tuple[str, str]], old_metadata_dir: Path, worki
             else:
                 violations.append(f"Modified existing file (only metadata.json and MODULE.bazel files can be modified): {file_path}")
                 continue
+
+    for pkg, ver in sorted(affected_versions):
+        rel_ver_path = f"{target_dir.rstrip('/')}/{pkg}/{ver}"
+        version_dir = working_dir / target_dir.rstrip("/") / pkg / ver
+        if version_dir.exists():
+            violations.extend(check_source_json_integrity(version_dir, rel_ver_path))
 
     return violations
 

--- a/tools/ci/check_pr_modules_test.py
+++ b/tools/ci/check_pr_modules_test.py
@@ -226,6 +226,109 @@ bazel_dep(name = "new_dep", version = "2.0.0")
         violations = check_violations(diffs, self.old_dir, self.work_dir, "modules")
         self.assertEqual(violations, [])
 
+    def test_source_json_integrity_valid(self):
+        # Valid source.json matching overlay and patches files passes
+        overlay_file = self.work_dir / "modules/my_module/1.0.0/overlay/BUILD.bazel"
+        overlay_file.parent.mkdir(parents=True, exist_ok=True)
+        overlay_file.write_text("# BUILD.bazel content\n")
+
+        patch_file = self.work_dir / "modules/my_module/1.0.0/patches/fix.patch"
+        patch_file.parent.mkdir(parents=True, exist_ok=True)
+        patch_file.write_text("--- a/foo\n+++ b/foo\n")
+
+        from tools.ci.bzlmod_lib import calculate_integrity_hash_for_file
+        source_data = {
+            "url": "https://example.com/archive.tar.gz",
+            "integrity": "sha256-dummy",
+            "overlay": {
+                "BUILD.bazel": calculate_integrity_hash_for_file(overlay_file),
+            },
+            "patches": {
+                "fix.patch": calculate_integrity_hash_for_file(patch_file),
+            },
+        }
+        self.write_json(self.work_dir, "modules/my_module/1.0.0/source.json", source_data)
+
+        diffs = [
+            ("A", "modules/my_module/1.0.0/MODULE.bazel"),
+            ("A", "modules/my_module/1.0.0/source.json"),
+            ("A", "modules/my_module/1.0.0/overlay/BUILD.bazel"),
+            ("A", "modules/my_module/1.0.0/patches/fix.patch"),
+        ]
+        violations = check_violations(diffs, self.old_dir, self.work_dir, "modules")
+        self.assertEqual(violations, [])
+
+    def test_source_json_missing_when_overlay_exists(self):
+        # Missing source.json when overlay exists fails
+        overlay_file = self.work_dir / "modules/my_module/1.0.0/overlay/BUILD.bazel"
+        overlay_file.parent.mkdir(parents=True, exist_ok=True)
+        overlay_file.write_text("# BUILD.bazel\n")
+
+        diffs = [
+            ("A", "modules/my_module/1.0.0/overlay/BUILD.bazel"),
+        ]
+        violations = check_violations(diffs, self.old_dir, self.work_dir, "modules")
+        self.assertIn("Missing source.json in modules/my_module/1.0.0", violations)
+
+    def test_source_json_overlay_hash_mismatch(self):
+        # Mismatch in overlay file hash fails with clear violation
+        overlay_file = self.work_dir / "modules/my_module/1.0.0/overlay/BUILD.bazel"
+        overlay_file.parent.mkdir(parents=True, exist_ok=True)
+        overlay_file.write_text("# Updated BUILD.bazel content\n")
+
+        source_data = {
+            "url": "https://example.com/archive.tar.gz",
+            "integrity": "sha256-dummy",
+            "overlay": {
+                "BUILD.bazel": "sha256-stalehash1234567890=",
+            },
+        }
+        self.write_json(self.work_dir, "modules/my_module/1.0.0/source.json", source_data)
+
+        diffs = [
+            ("A", "modules/my_module/1.0.0/overlay/BUILD.bazel"),
+            ("A", "modules/my_module/1.0.0/source.json"),
+        ]
+        violations = check_violations(diffs, self.old_dir, self.work_dir, "modules")
+        self.assertTrue(any("Integrity mismatch for overlay 'BUILD.bazel'" in v for v in violations))
+
+    def test_source_json_undeclared_overlay_file(self):
+        # Overlay file exists on disk but is not declared in source.json
+        overlay_file = self.work_dir / "modules/my_module/1.0.0/overlay/BUILD.bazel"
+        overlay_file.parent.mkdir(parents=True, exist_ok=True)
+        overlay_file.write_text("# BUILD.bazel\n")
+
+        source_data = {
+            "url": "https://example.com/archive.tar.gz",
+            "integrity": "sha256-dummy",
+            "overlay": {},
+        }
+        self.write_json(self.work_dir, "modules/my_module/1.0.0/source.json", source_data)
+
+        diffs = [
+            ("A", "modules/my_module/1.0.0/overlay/BUILD.bazel"),
+            ("A", "modules/my_module/1.0.0/source.json"),
+        ]
+        violations = check_violations(diffs, self.old_dir, self.work_dir, "modules")
+        self.assertIn("File 'BUILD.bazel' exists in modules/my_module/1.0.0/overlay but is missing from source.json overlay list", violations)
+
+    def test_source_json_missing_overlay_file_on_disk(self):
+        # source.json declares an overlay file that does not exist on disk
+        source_data = {
+            "url": "https://example.com/archive.tar.gz",
+            "integrity": "sha256-dummy",
+            "overlay": {
+                "nonexistent.bazel": "sha256-dummyhash=",
+            },
+        }
+        self.write_json(self.work_dir, "modules/my_module/1.0.0/source.json", source_data)
+
+        diffs = [
+            ("A", "modules/my_module/1.0.0/source.json"),
+        ]
+        violations = check_violations(diffs, self.old_dir, self.work_dir, "modules")
+        self.assertIn("Overlay file 'nonexistent.bazel' declared in modules/my_module/1.0.0/source.json does not exist on disk", violations)
+
 
 class TestMain(unittest.TestCase):
     """


### PR DESCRIPTION
## Summary

- Renames bot to @gemini-bot.
- Adds `check_source_json_integrity` to `tools/ci/check_pr_modules.py` to validate that every file in `overlay/` and `patches/` matches its SHA-256 integrity hash in `source.json`, and that no declared files are missing on disk or undeclared. Also adds tests to exercise these checks.
- Updates gemini workflows to call out the lint/test/integrity ordering in the prompt.

## Acknowledgements

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Code of Conduct](../CODE_OF_CONDUCT.md) and agree to abide by it.
- [x] I have read and complied with the [OSRF Policy on the Use of Generative AI Tools ("Generative AI") in Contributions](https://github.com/openrobotics/osra-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md).

## Generative AI disclosure

- Was any generative AI tool used in this contribution? No
- If yes, which tool(s), and for which part(s) of the contribution?

## Related issue(s)

- Fixes:

## Additional information

Tested locally with all 195 unit tests in `tools/ci/` passing.