### PR TITLE
bugfix: update module diffing logic to include patches and overlays

### DIFF
--- a/.github/workflows/_check_bazel_modules.yml
+++ b/.github/workflows/_check_bazel_modules.yml
@@ -40,6 +40,7 @@ env:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   check_bazel_modules:
@@ -99,6 +100,51 @@ jobs:
           echo "### Module diff (${{ matrix.directory }})" >> "$GITHUB_STEP_SUMMARY"
           cat /tmp/module_diff.md >> "$GITHUB_STEP_SUMMARY"
         fi
+    - name: Post or update module diff PR comment
+      # Posts or updates the PR comment directly for non-fork PRs where
+      # pull-requests: write is granted. On fork PRs (where GITHUB_TOKEN
+      # is read-only), continue-on-error skips failure and lets the
+      # workflow_run listener (post_module_diff_comment.yml) handle it.
+      if: always() && github.event_name == 'pull_request'
+      uses: actions/github-script@v9
+      continue-on-error: true
+      with:
+        script: |
+          const fs = require('fs');
+          const diffPath = '/tmp/module_diff.md';
+          if (!fs.existsSync(diffPath)) return;
+          const diff = fs.readFileSync(diffPath, 'utf8').trim();
+          if (!diff) return;
+
+          const directory = '${{ matrix.directory }}';
+          const marker = `<!-- module-diff: ${directory} -->`;
+          const body = `${marker}\n${diff}`;
+
+          const issueNumber = context.payload.pull_request ? context.payload.pull_request.number : context.issue.number;
+          if (!issueNumber) return;
+
+          const { data: comments } = await github.rest.issues.listComments({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: issueNumber,
+          });
+
+          const existing = comments.find((c) => c.body.includes(marker));
+          if (existing) {
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: existing.id,
+              body,
+            });
+          } else {
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              body,
+            });
+          }
     - name: Compute artifact name
       # Artifact names can't contain '/', so sanitize the matrix directory
       # (e.g. "bcr_staging/modules" -> "bcr_staging-modules"). The

--- a/.github/workflows/check_bazel_modules.yml
+++ b/.github/workflows/check_bazel_modules.yml
@@ -36,6 +36,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 concurrency:
   group: check-bazel-modules-${{ github.ref }}

--- a/tools/ci/module_diff.py
+++ b/tools/ci/module_diff.py
@@ -82,7 +82,7 @@ MAX_DIFF_LINES = 300
 
 
 def diff_module_versions(
-    modules_dir: Path, package: str, old_version: str, new_version: str
+    modules_dir: Path, package: str, old_version: Optional[str], new_version: str
 ) -> str:
     """
     Unified diff (diff -ruN) between two version directories of the same
@@ -90,20 +90,47 @@ def diff_module_versions(
     fair game to review, since they're everything a new version adds. Runs
     with cwd set to the package directory so the diff headers show clean
     version-relative paths (e.g. "1.0.0/source.json") instead of a noisy,
-    non-portable absolute host path.
+    non-portable absolute host path. If old_version is None (first-ever
+    version of a package), diffs against an empty directory so every
+    newly-added file is shown.
     """
-    result = subprocess.run(
-        ["diff", "-ruN", old_version, new_version],
-        cwd=modules_dir / package,
-        capture_output=True,
-        text=True,
-    )
-    lines = result.stdout.splitlines(keepends=True)
+    if old_version is None:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as empty_dir:
+            result = subprocess.run(
+                ["diff", "-ruN", empty_dir, new_version],
+                cwd=modules_dir / package,
+                capture_output=True,
+                text=True,
+            )
+        lines = []
+        for line in result.stdout.splitlines(keepends=True):
+            if line.startswith("diff -ruN "):
+                parts = line.strip().split()
+                if len(parts) == 4:
+                    lines.append(f"diff -ruN /dev/null {parts[3]}\n")
+                    continue
+            elif line.startswith("--- "):
+                lines.append("--- /dev/null\n")
+                continue
+            lines.append(line)
+        stdout = "".join(lines)
+    else:
+        result = subprocess.run(
+            ["diff", "-ruN", old_version, new_version],
+            cwd=modules_dir / package,
+            capture_output=True,
+            text=True,
+        )
+        stdout = result.stdout
+
+    lines = stdout.splitlines(keepends=True)
     if len(lines) > MAX_DIFF_LINES:
         truncated = "".join(lines[:MAX_DIFF_LINES])
         truncated += f"\n... (truncated {len(lines) - MAX_DIFF_LINES} lines)\n"
         return truncated
-    return result.stdout
+    return stdout
 
 
 def render_module_diff_markdown(
@@ -119,25 +146,30 @@ def render_module_diff_markdown(
     sections = []
     for package, version in new_versions:
         previous = find_previous_version(modules_dir, package, version)
-        if previous is None:
-            sections.append(
-                f"<details>\n<summary><code>{package}@{version}</code> "
-                "(first-ever version -- nothing to diff against)</summary>\n"
-                "</details>"
-            )
-            continue
-
         diff_text = diff_module_versions(modules_dir, package, previous, version)
         if not diff_text.strip():
-            sections.append(
-                f"<details>\n<summary><code>{package}@{version}</code> "
-                f"(identical to <code>{previous}</code>)</summary>\n</details>"
-            )
+            if previous is None:
+                sections.append(
+                    f"<details>\n<summary><code>{package}@{version}</code> "
+                    "(first-ever version -- empty)</summary>\n</details>"
+                )
+            else:
+                sections.append(
+                    f"<details>\n<summary><code>{package}@{version}</code> "
+                    f"(identical to <code>{previous}</code>)</summary>\n</details>"
+                )
             continue
 
+        if previous is None:
+            summary = f"<code>{package}@{version}</code> (new module)"
+        else:
+            summary = (
+                f"<code>{package}</code>: "
+                f"<code>{previous}</code> &rarr; <code>{version}</code>"
+            )
+
         sections.append(
-            f"<details>\n<summary><code>{package}</code>: "
-            f"<code>{previous}</code> &rarr; <code>{version}</code></summary>\n\n"
+            f"<details>\n<summary>{summary}</summary>\n\n"
             f"```diff\n{diff_text}```\n\n</details>"
         )
 

--- a/tools/ci/module_diff_test.py
+++ b/tools/ci/module_diff_test.py
@@ -129,6 +129,18 @@ class TestDiffModuleVersions(unittest.TestCase):
         self.assertEqual(diff_text.strip(), "")
 
 
+    def test_diff_module_versions_none_old_version(self):
+        new_dir = self.modules_dir / "new_pkg" / "1.0.0"
+        (new_dir / "patches").mkdir(parents=True)
+        (new_dir / "MODULE.bazel").write_text('version = "1.0.0"\n')
+        (new_dir / "patches" / "0001.patch").write_text("patch\n")
+
+        diff_text = module_diff.diff_module_versions(self.modules_dir, "new_pkg", None, "1.0.0")
+        self.assertIn("+version = \"1.0.0\"", diff_text)
+        self.assertIn("0001.patch", diff_text)
+        self.assertIn("/dev/null", diff_text)
+
+
 class TestRenderModuleDiffMarkdown(unittest.TestCase):
 
     def setUp(self):
@@ -140,11 +152,14 @@ class TestRenderModuleDiffMarkdown(unittest.TestCase):
     def test_no_new_versions_renders_nothing(self):
         self.assertEqual(module_diff.render_module_diff_markdown(self.modules_dir, []), "")
 
-    def test_first_ever_version_notes_nothing_to_diff(self):
-        (self.modules_dir / "new_pkg" / "0.0.0").mkdir(parents=True)
+    def test_first_ever_version_renders_new_module_diff(self):
+        new_dir = self.modules_dir / "new_pkg" / "0.0.0"
+        new_dir.mkdir(parents=True)
+        (new_dir / "MODULE.bazel").write_text('module(name = "new_pkg", version = "0.0.0")\n')
         result = module_diff.render_module_diff_markdown(self.modules_dir, [("new_pkg", "0.0.0")])
         self.assertIn("new_pkg@0.0.0", result)
-        self.assertIn("nothing to diff against", result)
+        self.assertIn("new module", result)
+        self.assertIn("```diff", result)
 
     def test_real_change_renders_diff_fence(self):
         old_dir = self.modules_dir / "rclcpp" / "1.0.0"


### PR DESCRIPTION
## Summary

In PR #198 (backward_ros), the initial commit added 1.0.8-5.rcr.2 with MODULE.bazel and overlay/BUILD.bazel, which created the initial PR comment. When subsequent commits added patches (test___test_main__cpp.patch and test__suicide__cpp.patch) the PR comment on PR #198 was never updated to include the patches. This fixes the problem, ensuring that all differences are included and updated correctly on new commits.

## Acknowledgements

- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have read the [Code of Conduct](../CODE_OF_CONDUCT.md) and agree to abide by it.
- [x] I have read and complied with the [OSRF Policy on the Use of Generative AI Tools ("Generative AI") in Contributions](https://github.com/openrobotics/osra-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md).

## Generative AI disclosure

<!--
Per the OSRF Generative AI policy linked above, disclose whether -- and how
-- generative/AI tools were used anywhere in this contribution (e.g. code,
tests, commit messages, this PR description).
-->

- Was any generative AI tool used in this contribution? Yes
- If yes, which tool(s), and for which part(s) of the contribution? Helping come up with the solution

## Related issue(s)

<!--
Does this PR fix a known, reported issue? Link it (e.g. "Fixes #123") so it
closes automatically on merge. If there's no tracked issue, say so.
-->

- Fixes: https://github.com/intrinsic-opensource/ros-central-registry/issues/206

## Additional information

<!-- Anything else reviewers should know: testing performed, follow-up work, open questions, etc. -->
